### PR TITLE
add host locality information to splits

### DIFF
--- a/src/main/java/com/rapleaf/hank/hadoop/HadoopDomainCompactor.java
+++ b/src/main/java/com/rapleaf/hank/hadoop/HadoopDomainCompactor.java
@@ -231,7 +231,7 @@ public class HadoopDomainCompactor extends AbstractHadoopDomainBuilder {
           List<String> paths = updater.getRemotePartitionFilePaths(updatePlan);
           LOG.info("Determining locations for partition " + partition + " using: " + paths);
           locations = computeOptimalHosts(conf, paths);
-          LOG.info("Found locations: " + locations);
+          LOG.info("Determining locations for partition " + partition + " : " + locations);
         }
 
         splits[partition] = new HadoopDomainCompactorInputSplit(domainName, partition, locations.toArray(new String[locations.size()]));


### PR DESCRIPTION
Pretty much copy/pasted from the locality code in our FileListSplit. For each location in the split, we query the file system for the hosts with that files blocks, and add up the block sizes for each host to see who has most. We give the hosts names, sorted, to the JobTracker to suggest hosts to run our tasks on.

@andrerodriguez should probably check this over and make sure I didn't mess anything up in the copying.
