### PR TITLE
add cascading_ext dep and use trash helper

### DIFF
--- a/hank-server/pom.xml
+++ b/hank-server/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.liveramp</groupId>
+      <artifactId>cascading_ext</artifactId>
+      <version>1.5</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20090211</version>

--- a/hank-server/src/main/java/com/liveramp/hank/hadoop/DomainBuilderOutputCommitter.java
+++ b/hank-server/src/main/java/com/liveramp/hank/hadoop/DomainBuilderOutputCommitter.java
@@ -16,6 +16,7 @@
 
 package com.liveramp.hank.hadoop;
 
+import com.liveramp.cascading_ext.fs.TrashHelper;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -105,7 +106,7 @@ public class DomainBuilderOutputCommitter extends FileOutputCommitter {
     FileSystem fs = tmpOutputPath.getFileSystem(conf);
     if (fs.exists(tmpOutputPath)) {
       LOG.info("Deleting temporary output path " + tmpOutputPath);
-      fs.delete(tmpOutputPath, true);
+      TrashHelper.deleteUsingTrashIfEnabled(fs, tmpOutputPath);
     }
   }
 }

--- a/hank-server/src/main/java/com/liveramp/hank/storage/HdfsPartitionRemoteFileOps.java
+++ b/hank-server/src/main/java/com/liveramp/hank/storage/HdfsPartitionRemoteFileOps.java
@@ -16,6 +16,7 @@
 
 package com.liveramp.hank.storage;
 
+import com.liveramp.cascading_ext.fs.TrashHelper;
 import com.liveramp.hank.util.IOStreamUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -127,7 +128,7 @@ public class HdfsPartitionRemoteFileOps implements PartitionRemoteFileOps {
   @Override
   public boolean attemptDelete(String remoteRelativePath) throws IOException {
     if (exists(remoteRelativePath)) {
-      fs.delete(new Path(getRemoteAbsolutePath(remoteRelativePath)), true);
+      TrashHelper.deleteUsingTrashIfEnabled(fs, new Path(getRemoteAbsolutePath(remoteRelativePath)));
     }
     return true;
   }

--- a/hank-server/src/test/java/com/liveramp/hank/hadoop/HadoopTestCase.java
+++ b/hank-server/src/test/java/com/liveramp/hank/hadoop/HadoopTestCase.java
@@ -34,7 +34,7 @@ public abstract class HadoopTestCase extends BaseTestCase {
   protected final String INPUT_DIR;
   protected final String OUTPUT_DIR;
 
-  public HadoopTestCase(Class<? extends Object> cls) throws IOException {
+  public HadoopTestCase(Class<?> cls) throws IOException {
     super();
     this.fs = FileSystem.get(new Configuration());
     TEST_DIR = "/tmp/test_" + cls.getName();

--- a/hank-server/src/test/java/com/liveramp/hank/storage/TestHdfsPartitionRemoteFileOps.java
+++ b/hank-server/src/test/java/com/liveramp/hank/storage/TestHdfsPartitionRemoteFileOps.java
@@ -16,28 +16,27 @@
 
 package com.liveramp.hank.storage;
 
-import com.liveramp.hank.test.BaseTestCase;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
+import com.liveramp.hank.hadoop.HadoopTestCase;
 import org.apache.hadoop.fs.Path;
 
 import java.io.File;
 import java.io.IOException;
 
-public class TestHdfsPartitionRemoteFileOps extends BaseTestCase {
+public class TestHdfsPartitionRemoteFileOps extends HadoopTestCase {
 
-  private final String ROOT = localTmpDir + "/hdfs/";
-  private FileSystem fs;
+  private String ROOT;
   private HdfsPartitionRemoteFileOps hdfsFileOps;
 
+  public TestHdfsPartitionRemoteFileOps() throws IOException {
+    super(TestHdfsPartitionRemoteFileOps.class);
+  }
+
   @Override
-  protected void setUp() throws Exception {
+  public void setUp() throws Exception {
     super.setUp();
 
-    fs = FileSystem.get(new Configuration());
-    System.out.println(fs.toString());
-    fs.delete(new Path(ROOT), true);
-    fs.mkdirs(new Path(ROOT));
+    ROOT = TEST_DIR + "/hdfs/";
+
     fs.create(new Path(ROOT, "0/file1.txt")).close();
     fs.create(new Path(ROOT, "0/file2.txt")).close();
     hdfsFileOps = new HdfsPartitionRemoteFileOps(ROOT, 0);


### PR DESCRIPTION
More cleanup we can do later after this gets added as a dependency (some FlowConnectorFactory nonsense and we can factor out some file locality logic).
