### PR TITLE
add shutdown countdown thread 

### DIFF
--- a/hank-server/src/main/java/com/liveramp/hank/partition_server/PartitionServer.java
+++ b/hank-server/src/main/java/com/liveramp/hank/partition_server/PartitionServer.java
@@ -197,12 +197,12 @@ public class PartitionServer implements HostCommandQueueChangeListener, WatchedN
 
       private void startShutDownCountdown(long units, TimeUnit unit) {
         try {
-          //TODO set these via config
           unit.sleep(units);
           HostState state = getStateSafe();
           if (state == null || HostState.OFFLINE.equals(state)) {
             LOG.info("Partition Server was OFFLINE for " + units + " " + unit.toString());
-            stopSynchronized();
+            LOG.error("Would have shutdown");
+            //stopSynchronized();
           }
         } catch (InterruptedException e) {
           LOG.error("Interrupted while performing shutdown countdown", e);
@@ -211,6 +211,7 @@ public class PartitionServer implements HostCommandQueueChangeListener, WatchedN
     };
 
     offlineWatcherThread = new Thread(serverOfflineWatcher, "Server Offline Watcher");
+    offlineWatcherThread.setDaemon(true);
     offlineWatcherThread.start();
   }
 


### PR DESCRIPTION
Thread will shutdown the partition server if it's been offline for 10 minutes - this usually means it lost it's ZK connection. Having the partition server process actually quit means we can have some other process automatically restart it on process death.
