### PR TITLE
make zkp wrap rather than extend ZooKeeper

### DIFF
--- a/hank-core/src/main/java/com/liveramp/hank/test/ZkTestCase.java
+++ b/hank-core/src/main/java/com/liveramp/hank/test/ZkTestCase.java
@@ -112,7 +112,8 @@ public abstract class ZkTestCase extends BaseTestCase {
     final Object lock = new Object();
     final AtomicBoolean connected = new AtomicBoolean(false);
 
-    zk = new ZooKeeperPlus("127.0.0.1:" + zkClientPort, 1000000, new Watcher() {
+    zk = new ZooKeeperPlus();
+    zk.reconnect("127.0.0.1:" + zkClientPort, 1000000, new Watcher() {
       @Override
       public void process(WatchedEvent event) {
         switch (event.getType()) {

--- a/hank-core/src/main/java/com/liveramp/hank/zookeeper/NodeCreationBarrier.java
+++ b/hank-core/src/main/java/com/liveramp/hank/zookeeper/NodeCreationBarrier.java
@@ -4,7 +4,6 @@ import org.apache.log4j.Logger;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooKeeper;
 
 public class NodeCreationBarrier implements Watcher {
 
@@ -12,19 +11,19 @@ public class NodeCreationBarrier implements Watcher {
 
   private boolean waiting = true;
   private final String nodePath;
-  private final ZooKeeper zk;
+  private final ZooKeeperPlus zk;
 
   // Will block until specified node is created or connection is lost
-  public static void block(ZooKeeper zk, String nodePath) throws InterruptedException, KeeperException {
+  public static void block(ZooKeeperPlus zk, String nodePath) throws InterruptedException, KeeperException {
     new NodeCreationBarrier(zk, nodePath).block();
   }
 
   // Will block until specified node is created or connection is lost or timeout is exceeded
-  public static void block(ZooKeeper zk, String nodePath, int timeoutMS) throws InterruptedException, KeeperException {
+  public static void block(ZooKeeperPlus zk, String nodePath, int timeoutMS) throws InterruptedException, KeeperException {
     new NodeCreationBarrier(zk, nodePath).block(timeoutMS);
   }
 
-  public NodeCreationBarrier(ZooKeeper zk, String nodePath) throws InterruptedException, KeeperException {
+  public NodeCreationBarrier(ZooKeeperPlus zk, String nodePath) throws InterruptedException, KeeperException {
     this.nodePath = nodePath;
     this.zk = zk;
   }


### PR DESCRIPTION
Allows anything with a set ZkHost (which holds onto a ZKP) to benefits from reconnects and not stay disconnected.  Specifically we noticed this on the UpdateFilesystemStatisticsRunnable thread, where it would never reconnect, but a lot of stuff in PartitionServer holds onto the same ZkHost as well, so I feel like this should help a lot of the issues we have with PartitionServer not recovering after losing zk connections.

@thomas-kielbus would love to have your thoughts if you have a chance
@pwestling 