### PR TITLE
don't panic

### DIFF
--- a/hank-core/src/main/java/com/liveramp/hank/storage/FileOpsUtil.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/FileOpsUtil.java
@@ -1,0 +1,32 @@
+package com.liveramp.hank.storage;
+
+import java.util.Map;
+
+import static com.liveramp.hank.storage.curly.Curly.Factory.REMOTE_DOMAIN_ROOT_KEY;
+
+public class FileOpsUtil {
+
+  public static final String PARTITION_SERVER_DOMAIN_ROOT_KEY = "partition_server_remote_domain_root";
+  public static final String DOMAIN_BUILDER_DOMAIN_ROOT_KEY = "partition_server_remote_domain_root";
+
+
+  public static String getPartitionServerRoot(Map<String, Object> options){
+
+    if(options.containsKey(REMOTE_DOMAIN_ROOT_KEY)){
+      return (String)options.get(REMOTE_DOMAIN_ROOT_KEY);
+    }
+
+    return (String) options.get(PARTITION_SERVER_DOMAIN_ROOT_KEY);
+
+  }
+
+  public static String getDomainBuilderRoot(Map<String, Object> options){
+
+    if(options.containsKey(REMOTE_DOMAIN_ROOT_KEY)){
+      return (String)options.get(REMOTE_DOMAIN_ROOT_KEY);
+    }
+
+    return (String) options.get(DOMAIN_BUILDER_DOMAIN_ROOT_KEY);
+  }
+
+}

--- a/hank-core/src/main/java/com/liveramp/hank/storage/FileOpsUtil.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/FileOpsUtil.java
@@ -7,7 +7,7 @@ import static com.liveramp.hank.storage.curly.Curly.Factory.REMOTE_DOMAIN_ROOT_K
 public class FileOpsUtil {
 
   public static final String PARTITION_SERVER_DOMAIN_ROOT_KEY = "partition_server_remote_domain_root";
-  public static final String DOMAIN_BUILDER_DOMAIN_ROOT_KEY = "partition_server_remote_domain_root";
+  public static final String DOMAIN_BUILDER_DOMAIN_ROOT_KEY = "domain_builder_remote_domain_root";
 
 
   public static String getPartitionServerRoot(Map<String, Object> options){

--- a/hank-core/src/main/java/com/liveramp/hank/storage/StorageEngine.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/StorageEngine.java
@@ -51,9 +51,14 @@ public interface StorageEngine {
 
   public ByteBuffer getComparableKey(ByteBuffer key);
 
-  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory();
+  enum RemoteLocation {
+    DOMAIN_BUILDER,
+    PARTITION_SERVER
+  }
 
-  public PartitionRemoteFileOps getPartitionRemoteFileOps(int partitionNumber) throws IOException;
+  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory(RemoteLocation filesLocation);
+
+  public PartitionRemoteFileOps getPartitionRemoteFileOps(RemoteLocation files, int partitionNumber) throws IOException;
 
   public RemoteDomainVersionDeleter getRemoteDomainVersionDeleter() throws IOException;
 

--- a/hank-core/src/main/java/com/liveramp/hank/storage/cueball/Cueball.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/cueball/Cueball.java
@@ -82,7 +82,7 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
     public static final String NUM_REMOTE_LEAF_VERSIONS_TO_KEEP = "num_remote_leaf_versions_to_keep";
 
     private static final Set<String> REQUIRED_KEYS =
-        new HashSet<String>(Arrays.asList(REMOTE_DOMAIN_ROOT_KEY,
+        new HashSet<String>(Arrays.asList(
             HASH_INDEX_BITS_KEY,
             HASHER_KEY,
             VALUE_SIZE_KEY,

--- a/hank-core/src/main/java/com/liveramp/hank/storage/cueball/Cueball.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/cueball/Cueball.java
@@ -46,6 +46,7 @@ import com.liveramp.hank.hasher.IdentityHasher;
 import com.liveramp.hank.partition_server.DiskPartitionAssignment;
 import com.liveramp.hank.storage.Compactor;
 import com.liveramp.hank.storage.Deleter;
+import com.liveramp.hank.storage.FileOpsUtil;
 import com.liveramp.hank.storage.PartitionRemoteFileOps;
 import com.liveramp.hank.storage.PartitionRemoteFileOpsFactory;
 import com.liveramp.hank.storage.PartitionUpdater;
@@ -127,7 +128,8 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
           hasher,
           (Integer)options.get(VALUE_SIZE_KEY),
           (Integer)options.get(HASH_INDEX_BITS_KEY),
-          (String)options.get(REMOTE_DOMAIN_ROOT_KEY),
+          FileOpsUtil.getDomainBuilderRoot(options),
+          FileOpsUtil.getPartitionServerRoot(options),
           fileOpsFactory,
           compressionCodecClass,
           domain,
@@ -151,7 +153,8 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
   private final Hasher hasher;
   private final int valueSize;
   private final int hashIndexBits;
-  private final String remoteDomainRoot;
+  private final String domainBuilderRemoteDomainRoot;
+  private final String partitionServerRemoteDomainRoot;
   private final PartitionRemoteFileOpsFactory partitionRemoteFileOpsFactory;
   private final ByteBuffer keyHashBuffer;
   private final int numRemoteLeafVersionsToKeep;
@@ -162,7 +165,8 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
                  Hasher hasher,
                  int valueSize,
                  int hashIndexBits,
-                 String remoteDomainRoot,
+                 String domainBuilderRemoteDomainRoot,
+                 String partitionServerRemoteDomainRoot,
                  PartitionRemoteFileOpsFactory partitionRemoteFileOpsFactory,
                  Class<? extends CueballCompressionCodec> compressionCodecClass,
                  Domain domain,
@@ -171,7 +175,8 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
     this.hasher = hasher;
     this.valueSize = valueSize;
     this.hashIndexBits = hashIndexBits;
-    this.remoteDomainRoot = remoteDomainRoot;
+    this.domainBuilderRemoteDomainRoot = domainBuilderRemoteDomainRoot;
+    this.partitionServerRemoteDomainRoot = partitionServerRemoteDomainRoot;
     this.partitionRemoteFileOpsFactory = partitionRemoteFileOpsFactory;
     this.keyHashBuffer = ByteBuffer.allocate(keyHashSize);
     this.compressionCodecClass = compressionCodecClass;
@@ -237,7 +242,7 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
   public PartitionUpdater getUpdater(DiskPartitionAssignment assignment, int partitionNumber) throws IOException {
     String localDir = getTargetDirectory(assignment, partitionNumber);
     return new CueballPartitionUpdater(domain,
-        getPartitionRemoteFileOps(partitionNumber),
+        getPartitionRemoteFileOps(RemoteLocation.PARTITION_SERVER, partitionNumber),
         new CueballMerger(),
         keyHashSize,
         valueSize,
@@ -275,13 +280,13 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
   }
 
   @Override
-  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory() {
+  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory(RemoteLocation location) {
     return partitionRemoteFileOpsFactory;
   }
 
   @Override
-  public PartitionRemoteFileOps getPartitionRemoteFileOps(int partitionNumber) throws IOException {
-    return partitionRemoteFileOpsFactory.getPartitionRemoteFileOps(remoteDomainRoot, partitionNumber);
+  public PartitionRemoteFileOps getPartitionRemoteFileOps(RemoteLocation location, int partitionNumber) throws IOException {
+    return partitionRemoteFileOpsFactory.getPartitionRemoteFileOps(getRoot(location), partitionNumber);
   }
 
   @Override
@@ -338,7 +343,7 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
 
   @Override
   public RemoteDomainVersionDeleter getRemoteDomainVersionDeleter() throws IOException {
-    return new CueballRemoteDomainVersionDeleter(domain, remoteDomainRoot, partitionRemoteFileOpsFactory);
+    return new CueballRemoteDomainVersionDeleter(domain, domainBuilderRemoteDomainRoot, partitionRemoteFileOpsFactory);
   }
 
   @Override
@@ -365,7 +370,7 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
     Multimap<String, Integer> partitionsPerDisk = HashMultimap.create();
     for (String dataDirectory : sortedDataDirectories) {
 
-      int numToAssign = (int) Math.ceil(numPartitionsPerDisk * (partitionsPerDisk.keySet().size() + 1))
+      int numToAssign = (int)Math.ceil(numPartitionsPerDisk * (partitionsPerDisk.keySet().size() + 1))
           - partitionsPerDisk.values().size();
 
       for (int i = 0; i < numToAssign && !sortedPartitions.isEmpty(); i++) {
@@ -396,17 +401,30 @@ public class Cueball extends IncrementalStorageEngine implements StorageEngine {
     return result;
   }
 
+  private final String getRoot(RemoteLocation location) {
+    if (location == RemoteLocation.DOMAIN_BUILDER) {
+      return domainBuilderRemoteDomainRoot;
+    } else if (location == RemoteLocation.PARTITION_SERVER) {
+      return partitionServerRemoteDomainRoot;
+    } else {
+      throw new RuntimeException();
+    }
+  }
+
   @Override
   public String toString() {
-    return "Cueball [compressionCodecClass=" + compressionCodecClass
-        + ", domainName=" + domain.getName()
-        + ", fileOpsFactory=" + partitionRemoteFileOpsFactory
-        + ", hashIndexBits=" + hashIndexBits
-        + ", hasher=" + hasher
-        + ", keyHashSize=" + keyHashSize
-        + ", remoteDomainRoot=" + remoteDomainRoot
-        + ", valueSize=" + valueSize
-        + ", numRemoteLeafVersionsToKeep=" + numRemoteLeafVersionsToKeep
-        + "]";
+    return "Cueball{" +
+        "domain=" + domain +
+        ", keyHashSize=" + keyHashSize +
+        ", hasher=" + hasher +
+        ", valueSize=" + valueSize +
+        ", hashIndexBits=" + hashIndexBits +
+        ", domainBuilderRemoteDomainRoot='" + domainBuilderRemoteDomainRoot + '\'' +
+        ", partitionServerRemoteDomainRoot='" + partitionServerRemoteDomainRoot + '\'' +
+        ", partitionRemoteFileOpsFactory=" + partitionRemoteFileOpsFactory +
+        ", keyHashBuffer=" + keyHashBuffer +
+        ", numRemoteLeafVersionsToKeep=" + numRemoteLeafVersionsToKeep +
+        ", compressionCodecClass=" + compressionCodecClass +
+        '}';
   }
 }

--- a/hank-core/src/main/java/com/liveramp/hank/storage/cueball/TestDomainGenerator.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/cueball/TestDomainGenerator.java
@@ -1,12 +1,5 @@
 package com.liveramp.hank.storage.cueball;
 
-import com.liveramp.commons.util.BytesUtils;
-import com.liveramp.hank.compression.cueball.CueballCompressionCodec;
-import com.liveramp.hank.coordinator.mock.MockDomainVersion;
-import com.liveramp.hank.hasher.Hasher;
-import com.liveramp.hank.partitioner.Partitioner;
-import com.liveramp.hank.storage.LocalPartitionRemoteFileOps;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,6 +8,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
+import com.liveramp.commons.util.BytesUtils;
+import com.liveramp.hank.compression.cueball.CueballCompressionCodec;
+import com.liveramp.hank.coordinator.mock.MockDomainVersion;
+import com.liveramp.hank.hasher.Hasher;
+import com.liveramp.hank.partitioner.Partitioner;
+import com.liveramp.hank.storage.LocalPartitionRemoteFileOps;
 
 public class TestDomainGenerator {
 
@@ -56,7 +56,7 @@ public class TestDomainGenerator {
       partitionedKeys.get(partitionNumber).add(hash);
     }
 
-    final Cueball cueball = new Cueball(hashLength, h, valueLength, indexBits, "", null, codecClass, null, 0);
+    final Cueball cueball = new Cueball(hashLength, h, valueLength, indexBits, "", "", null, codecClass, null, 0);
 
     byte[] valueBytes = new byte[valueLength];
     for (Map.Entry<Integer, List<byte[]>> part : partitionedKeys.entrySet()) {

--- a/hank-core/src/main/java/com/liveramp/hank/storage/curly/Curly.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/curly/Curly.java
@@ -41,6 +41,7 @@ import com.liveramp.hank.hasher.Hasher;
 import com.liveramp.hank.partition_server.DiskPartitionAssignment;
 import com.liveramp.hank.storage.Compactor;
 import com.liveramp.hank.storage.Deleter;
+import com.liveramp.hank.storage.FileOpsUtil;
 import com.liveramp.hank.storage.PartitionRemoteFileOps;
 import com.liveramp.hank.storage.PartitionRemoteFileOpsFactory;
 import com.liveramp.hank.storage.PartitionUpdater;
@@ -145,7 +146,8 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
           maxAllowedPartSize,
           (Integer)options.get(HASH_INDEX_BITS_KEY),
           (Integer)options.get(RECORD_FILE_READ_BUFFER_BYTES_KEY),
-          (String)options.get(REMOTE_DOMAIN_ROOT_KEY),
+          FileOpsUtil.getDomainBuilderRoot(options),
+          FileOpsUtil.getPartitionServerRoot(options),
           fileOpsFactory,
           compressionCodecClass,
           domain,
@@ -173,7 +175,9 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
   private final int recordFileReadBufferBytes;
 
   private final Cueball cueballStorageEngine;
-  private final String remoteDomainRoot;
+  private final String domainBuilderRemoteDomainRoot;
+  private final String partitionServerRemoteDomainRoot;
+
   private final int keyHashSize;
   private final PartitionRemoteFileOpsFactory partitionRemoteFileOpsFactory;
   private final int hashIndexBits;
@@ -190,7 +194,8 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
                long maxAllowedPartSize,
                int hashIndexBits,
                int recordFileReadBufferBytes,
-               String remoteDomainRoot,
+               String domainBuilderRemoteDomainRoot,
+               String partitionServerRemoteDomainRoot,
                PartitionRemoteFileOpsFactory partitionRemoteFileOpsFactory,
                Class<? extends CueballCompressionCodec> keyFileCompressionCodecClass,
                Domain domain,
@@ -202,7 +207,8 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
     this.keyHashSize = keyHashSize;
     this.hashIndexBits = hashIndexBits;
     this.recordFileReadBufferBytes = recordFileReadBufferBytes;
-    this.remoteDomainRoot = remoteDomainRoot;
+    this.domainBuilderRemoteDomainRoot = domainBuilderRemoteDomainRoot;
+    this.partitionServerRemoteDomainRoot = partitionServerRemoteDomainRoot;
     this.partitionRemoteFileOpsFactory = partitionRemoteFileOpsFactory;
     this.keyFileCompressionCodecClass = keyFileCompressionCodecClass;
     this.domain = domain;
@@ -226,7 +232,8 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
         hasher,
         cueballValueNumBytes,
         hashIndexBits,
-        remoteDomainRoot,
+        domainBuilderRemoteDomainRoot,
+        partitionServerRemoteDomainRoot,
         partitionRemoteFileOpsFactory,
         keyFileCompressionCodecClass,
         domain,
@@ -332,7 +339,7 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
   private Compactor getCompactor(String localDir,
                                  int partitionNumber) throws IOException {
     return new CurlyCompactor(domain,
-        getPartitionRemoteFileOps(partitionNumber),
+        getPartitionRemoteFileOps(RemoteLocation.DOMAIN_BUILDER, partitionNumber),
         localDir,
         new CurlyCompactingMerger(recordFileReadBufferBytes),
         new CueballStreamBufferMergeSort.Factory(keyHashSize, cueballValueNumBytes, hashIndexBits, getCompressionCodec(), null),
@@ -349,7 +356,7 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
 
   private CurlyFastPartitionUpdater getFastPartitionUpdater(String localDir, int partNum) throws IOException {
     return new CurlyFastPartitionUpdater(domain,
-        getPartitionRemoteFileOps(partNum),
+        getPartitionRemoteFileOps(RemoteLocation.PARTITION_SERVER, partNum),
         new CurlyMerger(),
         new CueballMerger(),
         keyHashSize,
@@ -381,13 +388,23 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
   }
 
   @Override
-  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory() {
+  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory(RemoteLocation location) {
     return partitionRemoteFileOpsFactory;
   }
 
   @Override
-  public PartitionRemoteFileOps getPartitionRemoteFileOps(int partitionNumber) throws IOException {
-    return partitionRemoteFileOpsFactory.getPartitionRemoteFileOps(remoteDomainRoot, partitionNumber);
+  public PartitionRemoteFileOps getPartitionRemoteFileOps(RemoteLocation location, int partitionNumber) throws IOException {
+    return partitionRemoteFileOpsFactory.getPartitionRemoteFileOps(getRoot(location), partitionNumber);
+  }
+
+  private final String getRoot(RemoteLocation location){
+    if(location == RemoteLocation.DOMAIN_BUILDER){
+      return domainBuilderRemoteDomainRoot;
+    }else if(location == RemoteLocation.PARTITION_SERVER) {
+      return partitionServerRemoteDomainRoot;
+    }else{
+      throw new RuntimeException();
+    }
   }
 
   public static int parseVersionNumber(String name) {
@@ -434,7 +451,7 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
 
   @Override
   public RemoteDomainVersionDeleter getRemoteDomainVersionDeleter() throws IOException {
-    return new CurlyRemoteDomainVersionDeleter(domain, remoteDomainRoot, partitionRemoteFileOpsFactory);
+    return new CurlyRemoteDomainVersionDeleter(domain, domainBuilderRemoteDomainRoot, partitionRemoteFileOpsFactory);
   }
 
   @Override
@@ -461,20 +478,23 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
 
   @Override
   public String toString() {
-    return "Curly [compressionCodecClass=" + keyFileCompressionCodecClass
-        + ", cueballStorageEngine=" + cueballStorageEngine
-        + ", domainName=" + domain.getName()
-        + ", fileOpsFactory=" + partitionRemoteFileOpsFactory
-        + ", hashIndexBits=" + hashIndexBits
-        + ", keyHashSize=" + keyHashSize
-        + ", offsetNumBytes=" + offsetNumBytes
-        + ", recordFileReadBufferBytes=" + recordFileReadBufferBytes
-        + ", remoteDomainRoot=" + remoteDomainRoot
-        + ", numRemoteLeafVersionsToKeep=" + numRemoteLeafVersionsToKeep
-        + ", valueFoldingCacheSize=" + valueFoldingCacheCapacity
-        + ", blockCompressionCodec=" + blockCompressionCodec
-        + ", compressedBlockSizeThreshold=" + compressedBlockSizeThreshold
-        + ", offsetInBlockNumBytes=" + offsetInBlockNumBytes
-        + "]";
+    return "Curly{" +
+        "domain=" + domain +
+        ", offsetNumBytes=" + offsetNumBytes +
+        ", recordFileReadBufferBytes=" + recordFileReadBufferBytes +
+        ", cueballStorageEngine=" + cueballStorageEngine +
+        ", domainBuilderRemoteDomainRoot='" + domainBuilderRemoteDomainRoot + '\'' +
+        ", partitionServerRemoteDomainRoot='" + partitionServerRemoteDomainRoot + '\'' +
+        ", keyHashSize=" + keyHashSize +
+        ", partitionRemoteFileOpsFactory=" + partitionRemoteFileOpsFactory +
+        ", hashIndexBits=" + hashIndexBits +
+        ", keyFileCompressionCodecClass=" + keyFileCompressionCodecClass +
+        ", numRemoteLeafVersionsToKeep=" + numRemoteLeafVersionsToKeep +
+        ", valueFoldingCacheCapacity=" + valueFoldingCacheCapacity +
+        ", blockCompressionCodec=" + blockCompressionCodec +
+        ", compressedBlockSizeThreshold=" + compressedBlockSizeThreshold +
+        ", offsetInBlockNumBytes=" + offsetInBlockNumBytes +
+        ", cueballValueNumBytes=" + cueballValueNumBytes +
+        '}';
   }
 }

--- a/hank-core/src/main/java/com/liveramp/hank/storage/curly/Curly.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/curly/Curly.java
@@ -85,7 +85,7 @@ public class Curly extends IncrementalStorageEngine implements StorageEngine {
     private static final String COMPRESSED_BLOCK_SIZE_THRESHOLD = "compressed_block_size_threshold";
     private static final String OFFSET_IN_BLOCK_NUM_BYTES = "offset_in_block_num_bytes";
 
-    private static final Set<String> REQUIRED_KEYS = new HashSet<String>(Arrays.asList(REMOTE_DOMAIN_ROOT_KEY,
+    private static final Set<String> REQUIRED_KEYS = new HashSet<String>(Arrays.asList(
         RECORD_FILE_READ_BUFFER_BYTES_KEY, HASH_INDEX_BITS_KEY, MAX_ALLOWED_PART_SIZE_KEY, KEY_HASH_SIZE_KEY,
         FILE_OPS_FACTORY_KEY, HASHER_KEY, NUM_REMOTE_LEAF_VERSIONS_TO_KEEP));
 

--- a/hank-core/src/main/java/com/liveramp/hank/storage/curly/TestDomainGenerator.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/curly/TestDomainGenerator.java
@@ -16,13 +16,6 @@
 
 package com.liveramp.hank.storage.curly;
 
-import com.liveramp.commons.util.BytesUtils;
-import com.liveramp.hank.compression.cueball.CueballCompressionCodec;
-import com.liveramp.hank.coordinator.mock.MockDomainVersion;
-import com.liveramp.hank.hasher.Hasher;
-import com.liveramp.hank.partitioner.Partitioner;
-import com.liveramp.hank.storage.LocalPartitionRemoteFileOps;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +24,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
+import com.liveramp.commons.util.BytesUtils;
+import com.liveramp.hank.compression.cueball.CueballCompressionCodec;
+import com.liveramp.hank.coordinator.mock.MockDomainVersion;
+import com.liveramp.hank.hasher.Hasher;
+import com.liveramp.hank.partitioner.Partitioner;
+import com.liveramp.hank.storage.LocalPartitionRemoteFileOps;
 
 public class TestDomainGenerator {
 
@@ -81,7 +81,7 @@ public class TestDomainGenerator {
     }
 
     final Curly curly = new Curly(hashLength, h, 10L * 1024 * 1024 * 1024,
-        indexBits, 32 * 1024, "", null, codecClass, null, 0, -1, null, -1, -1);
+        indexBits, 32 * 1024, "", "", null, codecClass, null, 0, -1, null, -1, -1);
 
     for (Map.Entry<Integer, List<byte[]>> part : partitionedKeys.entrySet()) {
       Collections.sort(part.getValue(), new Comparator<byte[]>() {

--- a/hank-core/src/main/java/com/liveramp/hank/storage/echo/Echo.java
+++ b/hank-core/src/main/java/com/liveramp/hank/storage/echo/Echo.java
@@ -49,12 +49,12 @@ public class Echo implements StorageEngine {
   }
 
   @Override
-  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory() {
+  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory(RemoteLocation location) {
     return null;
   }
 
   @Override
-  public PartitionRemoteFileOps getPartitionRemoteFileOps(int partitionNumber) throws IOException {
+  public PartitionRemoteFileOps getPartitionRemoteFileOps(RemoteLocation location, int partitionNumber) throws IOException {
     return null;
   }
 

--- a/hank-core/src/test/java/com/liveramp/hank/storage/constant/ConstantStorageEngine.java
+++ b/hank-core/src/test/java/com/liveramp/hank/storage/constant/ConstantStorageEngine.java
@@ -103,12 +103,12 @@ public class ConstantStorageEngine implements StorageEngine {
   }
 
   @Override
-  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory() {
+  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory(RemoteLocation location) {
     return null;
   }
 
   @Override
-  public PartitionRemoteFileOps getPartitionRemoteFileOps(int partitionNumber) throws IOException {
+  public PartitionRemoteFileOps getPartitionRemoteFileOps(RemoteLocation location, int partitionNumber) throws IOException {
     return null;
   }
 

--- a/hank-server/src/main/java/com/liveramp/hank/hadoop/DomainBuilderAbstractOutputFormat.java
+++ b/hank-server/src/main/java/com/liveramp/hank/hadoop/DomainBuilderAbstractOutputFormat.java
@@ -174,7 +174,7 @@ public abstract class DomainBuilderAbstractOutputFormat
       writtenPartitions.add(partitionNumber);
       writer = getWriter(storageEngine,
           domainVersion,
-          storageEngine.getPartitionRemoteFileOpsFactory().getPartitionRemoteFileOps(writerOutputPath.toString(), partitionNumber),
+          storageEngine.getPartitionRemoteFileOpsFactory(StorageEngine.RemoteLocation.DOMAIN_BUILDER).getPartitionRemoteFileOps(writerOutputPath.toString(), partitionNumber),
           partitionNumber);
     }
 

--- a/hank-server/src/main/java/com/liveramp/hank/hadoop/DomainBuilderProperties.java
+++ b/hank-server/src/main/java/com/liveramp/hank/hadoop/DomainBuilderProperties.java
@@ -22,6 +22,7 @@ import com.liveramp.hank.coordinator.DomainVersion;
 import com.liveramp.hank.coordinator.DomainVersionProperties;
 import com.liveramp.hank.coordinator.RunWithCoordinator;
 import com.liveramp.hank.coordinator.RunnableWithCoordinator;
+import com.liveramp.hank.storage.FileOpsUtil;
 
 public class DomainBuilderProperties {
 
@@ -270,11 +271,8 @@ public class DomainBuilderProperties {
       if (options == null) {
         throw new RuntimeException("Empty options for domain: " + domainName);
       }
-      String result = (String)options.get(REMOTE_DOMAIN_ROOT_STORAGE_ENGINE_OPTION);
-      if (result == null) {
-        throw new RuntimeException("Could not load option: " + REMOTE_DOMAIN_ROOT_STORAGE_ENGINE_OPTION + " for domain: " + domainName + " from storage engine options.");
-      }
-      this.result = result;
+
+      this.result = FileOpsUtil.getDomainBuilderRoot(options);
     }
   }
 

--- a/hank-server/src/main/java/com/liveramp/hank/hadoop/HadoopDomainCompactor.java
+++ b/hank-server/src/main/java/com/liveramp/hank/hadoop/HadoopDomainCompactor.java
@@ -239,7 +239,7 @@ public class HadoopDomainCompactor extends AbstractHadoopDomainBuilder {
         if (storageEngine instanceof IncrementalStorageEngine) {
           IncrementalUpdatePlanner updatePlanner = ((IncrementalStorageEngine)storageEngine).getUpdatePlanner(domain);
           IncrementalUpdatePlan updatePlan = updatePlanner.computeUpdatePlan(domainVersionToCompact);
-          List<String> paths = updatePlanner.getRemotePartitionFilePaths(updatePlan, storageEngine.getPartitionRemoteFileOps(partition));
+          List<String> paths = updatePlanner.getRemotePartitionFilePaths(updatePlan, storageEngine.getPartitionRemoteFileOps(StorageEngine.RemoteLocation.DOMAIN_BUILDER, partition));
           locations = LocalityHelper.getHostsSortedByLocality(paths, conf);
         }
 

--- a/hank-server/src/main/java/com/liveramp/hank/performance/PerformanceTestCueball.java
+++ b/hank-server/src/main/java/com/liveramp/hank/performance/PerformanceTestCueball.java
@@ -16,6 +16,13 @@
 
 package com.liveramp.hank.performance;
 
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+
 import com.liveramp.hank.compression.cueball.NoCueballCompressionCodec;
 import com.liveramp.hank.coordinator.DomainVersion;
 import com.liveramp.hank.coordinator.mock.MockDomainVersion;
@@ -32,13 +39,6 @@ import com.liveramp.hank.util.FormatUtils;
 import com.liveramp.hank.util.HankTimer;
 import com.liveramp.hank.util.IOStreamUtils;
 
-import java.io.BufferedOutputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Collections;
-
 public class PerformanceTestCueball {
 
   private static final int VALUE_SIZE = 16;
@@ -48,8 +48,9 @@ public class PerformanceTestCueball {
   private static final int NUM_RECORDS_PER_BLOCK = 1000;
 
   private static Cueball getCueball(String localTmpDir) {
+    String root = localTmpDir + "/remote_domain_root";
     return new Cueball(
-        KEY_HASH_SIZE, new KeyHasher(HASH_INDEX_BITS), VALUE_SIZE, HASH_INDEX_BITS, localTmpDir + "/remote_domain_root",
+        KEY_HASH_SIZE, new KeyHasher(HASH_INDEX_BITS), VALUE_SIZE, HASH_INDEX_BITS, root, root,
         new LocalPartitionRemoteFileOps.Factory(), NoCueballCompressionCodec.class, null, 0);
   }
 

--- a/hank-server/src/main/java/com/liveramp/hank/storage/HdfsPartitionRemoteFileOps.java
+++ b/hank-server/src/main/java/com/liveramp/hank/storage/HdfsPartitionRemoteFileOps.java
@@ -24,11 +24,12 @@ import java.io.OutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.liveramp.cascading_ext.FileSystemHelper;
 import com.liveramp.cascading_ext.fs.TrashHelper;
 import com.liveramp.hank.util.IOStreamUtils;
 
@@ -94,7 +95,7 @@ public class HdfsPartitionRemoteFileOps implements PartitionRemoteFileOps {
     this.useTrash = useTrash;
     this.partitionRoot = remoteDomainRoot + "/" + partitionNumber;
     Path partitionRootPath = new Path(partitionRoot);
-    this.fs = FileSystem.get(new Configuration());
+    this.fs = FileSystemHelper.getFileSystemForPath(remoteDomainRoot);
     if (!partitionRootPath.isAbsolute()) {
       throw new IOException("Cannot initialize " + this.getClass().getSimpleName()
           + " with a non absolute remote partition root: "

--- a/hank-server/src/main/java/com/liveramp/hank/storage/map/MapStorageEngine.java
+++ b/hank-server/src/main/java/com/liveramp/hank/storage/map/MapStorageEngine.java
@@ -16,17 +16,17 @@
 
 package com.liveramp.hank.storage.map;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.liveramp.hank.coordinator.DomainVersion;
 import com.liveramp.hank.storage.NoOpPartitionRemoteFileOps;
 import com.liveramp.hank.storage.PartitionRemoteFileOps;
 import com.liveramp.hank.storage.PartitionRemoteFileOpsFactory;
 import com.liveramp.hank.storage.Writer;
 import com.liveramp.hank.storage.mock.MockStorageEngine;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.Map;
 
 // Storage engine used for testing. Stores key-value pairs in a static
 // partition map instead of writing them to an output stream. It is not thread
@@ -80,7 +80,7 @@ public class MapStorageEngine extends MockStorageEngine {
   }
 
   @Override
-  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory() {
+  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory(RemoteLocation location) {
     return new NoOpPartitionRemoteFileOps.Factory();
   }
 }

--- a/hank-server/src/main/java/com/liveramp/hank/storage/mock/MockStorageEngine.java
+++ b/hank-server/src/main/java/com/liveramp/hank/storage/mock/MockStorageEngine.java
@@ -85,12 +85,12 @@ public class MockStorageEngine implements StorageEngine {
   }
 
   @Override
-  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory() {
+  public PartitionRemoteFileOpsFactory getPartitionRemoteFileOpsFactory(RemoteLocation location) {
     return new HdfsPartitionRemoteFileOps.Factory();
   }
 
   @Override
-  public PartitionRemoteFileOps getPartitionRemoteFileOps(int partitionNumber) {
+  public PartitionRemoteFileOps getPartitionRemoteFileOps(RemoteLocation location, int partitionNumber) {
     return null;
   }
 

--- a/hank-server/src/test/java/com/liveramp/hank/storage/cueball/TestCueballRemoteDomainVersionDeleter.java
+++ b/hank-server/src/test/java/com/liveramp/hank/storage/cueball/TestCueballRemoteDomainVersionDeleter.java
@@ -43,7 +43,7 @@ public class TestCueballRemoteDomainVersionDeleter extends BaseTestCase {
   @Test
   public void testIt() throws Exception {
     final Cueball storageEngine = new Cueball(1,
-        new Murmur64Hasher(), 1, 1, localDiskRoot,
+        new Murmur64Hasher(), 1, 1, localDiskRoot, localDiskRoot,
         new LocalPartitionRemoteFileOps.Factory(), NoCueballCompressionCodec.class,
         new MockDomain("domain", 0, 1, null, null, null, null), 0);
     Writer writer = storageEngine.getWriter(new MockDomainVersion(1, 0L, new IncrementalDomainVersionProperties.Base()),

--- a/hank-server/src/test/java/com/liveramp/hank/storage/curly/TestCurlyRemoteDomainVersionDeleter.java
+++ b/hank-server/src/test/java/com/liveramp/hank/storage/curly/TestCurlyRemoteDomainVersionDeleter.java
@@ -42,7 +42,7 @@ public class TestCurlyRemoteDomainVersionDeleter extends ZkTestCase {
   @Test
   public void testIt() throws Exception {
     final Curly storageEngine = new Curly(1, new Murmur64Hasher(), 100000, 1, 1000, localDiskRoot,
-        new LocalPartitionRemoteFileOps.Factory(), NoCueballCompressionCodec.class,
+        localDiskRoot, new LocalPartitionRemoteFileOps.Factory(), NoCueballCompressionCodec.class,
         new MockDomain("domain", 0, 1, null, null, null, null),
         0, -1, null, -1, -1);
     Writer writer = storageEngine.getWriter(new MockDomainVersion(1, 0L, new IncrementalDomainVersionProperties.Base()),


### PR DESCRIPTION
This is pretty ugly but I tried for a day or two to come up with a better plan (splitting up the interfaces) and failed.  

The basic idea is that the behavior will stay the same on the current domain configurations (see FileOpsUtil), but if you specify separate partition_server_remote_domain_root and partition_server_remote_domain_root params, they will get used, respectively.  

@pwestling @sidoh or whoever else is even vaguely familiar with hank.