### PR TITLE
make ensureCreated recursive

### DIFF
--- a/hank-core/src/main/java/com/liveramp/hank/zookeeper/ZooKeeperPlus.java
+++ b/hank-core/src/main/java/com/liveramp/hank/zookeeper/ZooKeeperPlus.java
@@ -375,10 +375,24 @@ public class ZooKeeperPlus {
     }
 
     public void ensureCreated(String path, byte[] value, CreateMode createMode) throws InterruptedException, KeeperException {
-      if (exists(path, false) == null) {
+      if (!path.isEmpty() && exists(path, false) == null) {
+        ensureCreated(getParent(path), null, createMode);
         create(path, value, DEFAULT_ACL, createMode);
         NodeCreationBarrier.block(ZooKeeperPlus.this, path);
       }
+    }
+
+    private boolean isRootOrEmpty(String path){
+      return path.isEmpty() || path.equals("/");
+    }
+
+    // TODO I don't want to create a File, and idk what other API I can use for htis
+    private String getParent(String path){
+      if(isRootOrEmpty(path)){
+        throw new IllegalArgumentException();
+      }
+
+      return path.substring(0, path.lastIndexOf("/"));
     }
 
     public void deleteNodeRecursively(String path) throws InterruptedException, KeeperException {

--- a/hank-core/src/main/java/com/liveramp/hank/zookeeper/ZooKeeperPlus.java
+++ b/hank-core/src/main/java/com/liveramp/hank/zookeeper/ZooKeeperPlus.java
@@ -16,6 +16,7 @@
 
 package com.liveramp.hank.zookeeper;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
@@ -376,23 +377,10 @@ public class ZooKeeperPlus {
 
     public void ensureCreated(String path, byte[] value, CreateMode createMode) throws InterruptedException, KeeperException {
       if (!path.isEmpty() && exists(path, false) == null) {
-        ensureCreated(getParent(path), null, createMode);
+        ensureCreated(new File(path).getParent(), null, createMode);
         create(path, value, DEFAULT_ACL, createMode);
         NodeCreationBarrier.block(ZooKeeperPlus.this, path);
       }
-    }
-
-    private boolean isRootOrEmpty(String path){
-      return path.isEmpty() || path.equals("/");
-    }
-
-    // TODO I don't want to create a File, and idk what other API I can use for htis
-    private String getParent(String path){
-      if(isRootOrEmpty(path)){
-        throw new IllegalArgumentException();
-      }
-
-      return path.substring(0, path.lastIndexOf("/"));
     }
 
     public void deleteNodeRecursively(String path) throws InterruptedException, KeeperException {

--- a/hank-core/src/test/java/com/liveramp/hank/zookeeper/TestZooKeeperPlus.java
+++ b/hank-core/src/test/java/com/liveramp/hank/zookeeper/TestZooKeeperPlus.java
@@ -1,0 +1,43 @@
+package com.liveramp.hank.zookeeper;
+
+import java.util.Arrays;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.junit.Test;
+
+import com.liveramp.hank.test.ZkTestCase;
+
+import static org.junit.Assert.assertTrue;
+
+public class TestZooKeeperPlus extends  ZkTestCase {
+
+  @Test
+  public void testIt() throws Exception {
+
+    final ZooKeeperPlus zk = getZk();
+
+    zk.ensureCreated("/", null, CreateMode.PERSISTENT);
+    assertExists("/", zk);
+
+    zk.ensureCreated("/simple", "1".getBytes(), CreateMode.PERSISTENT);
+    assertExists("/simple", zk);
+
+    zk.ensureCreated("/simple", "2".getBytes(), CreateMode.PERSISTENT);
+    assertExists("/simple", zk);
+    assertTrue(Arrays.equals(zk.getData("/simple", false, null), "1".getBytes()));
+
+    zk.ensureCreated("/deeper/file", null, CreateMode.PERSISTENT);
+    assertExists("/deeper/file", zk);
+    assertExists("/deeper", zk);
+
+    zk.ensureCreated("/simple/even/deeper", "3".getBytes(), CreateMode.PERSISTENT);
+    assertTrue(Arrays.equals(zk.getData("/simple", false, null), "1".getBytes()));
+
+  }
+
+  private void assertExists(String path, ZooKeeperPlus zkp) throws KeeperException, InterruptedException {
+    assertTrue(zkp.exists(path, false) != null);
+  }
+
+}


### PR DESCRIPTION
@pwestling @sidoh 

I think this will let me avoid having some kind of annoying hank-bootstrap script when spinning up new zk ensembles; it ensuresCreated on the sub-dirs

/hank/domains,
/hank/ring_groups
/hank/domain_groups 

but not on the root /hank dir.  It's hard to imagine any way this is unsafe, and I wrote tests... but hank.