### PR TITLE
Make sure at least one replica per AZ is up at a time during updates

### DIFF
--- a/hank-client/src/main/java/com/liveramp/hank/config/EnvironmentValue.java
+++ b/hank-client/src/main/java/com/liveramp/hank/config/EnvironmentValue.java
@@ -17,4 +17,13 @@ public class EnvironmentValue {
   public String getValue() {
     return value;
   }
+
+
+  @Override
+  public String toString() {
+    return "EnvironmentValue{" +
+        "key='" + key + '\'' +
+        ", value='" + value + '\'' +
+        '}';
+  }
 }

--- a/hank-server/src/main/java/com/liveramp/hank/config/RingGroupConductorConfigurator.java
+++ b/hank-server/src/main/java/com/liveramp/hank/config/RingGroupConductorConfigurator.java
@@ -26,5 +26,12 @@ public interface RingGroupConductorConfigurator extends CoordinatorConfigurator 
 
   public int getMinRingFullyServingObservations();
 
+  public String getHostAvailabilityBucketFlag();
+
+  public int getMinServingReplicas();
+
+  public int getAvailabilityBucketMinServingReplicas();
+
   public RingGroupConductorMode getInitialMode();
+
 }

--- a/hank-server/src/main/java/com/liveramp/hank/config/yaml/YamlRingGroupConductorConfigurator.java
+++ b/hank-server/src/main/java/com/liveramp/hank/config/yaml/YamlRingGroupConductorConfigurator.java
@@ -1,17 +1,17 @@
 /**
- *  Copyright 2011 LiveRamp
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Copyright 2011 LiveRamp
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.liveramp.hank.config.yaml;
 
@@ -29,6 +29,12 @@ public class YamlRingGroupConductorConfigurator extends YamlCoordinatorConfigura
   public static final String MIN_RING_FULLY_SERVING_OBSERVATIONS_KEY = "min_ring_fully_serving_observations";
   public static final String RING_GROUP_NAME_KEY = "ring_group_name";
   public static final String INITIAL_MODE_KEY = "initial_mode";
+  public static final String HOST_AVAILABILITY_BUCKET_FLAG_KEY = "host_availability_bucket";
+  public static final String MIN_SERVING_REPLICAS = "min_serving_replicas";
+  public static final String AVAILABILITY_BUCKET_MIN_SERVING_REPLICAS = "availability_bucket_min_serving_replicas";
+
+
+  public static final Integer DEFAULT_MIN_SERVING_REPLICAS = 2;
 
   public YamlRingGroupConductorConfigurator(String configPath) throws IOException, InvalidConfigurationException {
     super(configPath);
@@ -47,6 +53,44 @@ public class YamlRingGroupConductorConfigurator extends YamlCoordinatorConfigura
   @Override
   public int getMinRingFullyServingObservations() {
     return getInteger(RING_GROUP_CONDUCTOR_SECTION_KEY, MIN_RING_FULLY_SERVING_OBSERVATIONS_KEY);
+  }
+
+  @Override
+  public String getHostAvailabilityBucketFlag() {
+    return getOptionalString(
+        RING_GROUP_CONDUCTOR_SECTION_KEY,
+        HOST_AVAILABILITY_BUCKET_FLAG_KEY
+    );
+  }
+
+  @Override
+  public int getMinServingReplicas() {
+
+    Integer minServingReplicas = getOptionalInteger(
+        RING_GROUP_CONDUCTOR_SECTION_KEY,
+        MIN_SERVING_REPLICAS
+    );
+
+    if(minServingReplicas == null){
+      return DEFAULT_MIN_SERVING_REPLICAS;
+    }
+
+    return minServingReplicas;
+  }
+
+  @Override
+  public int getAvailabilityBucketMinServingReplicas() {
+
+    Integer minServingReplicas = getOptionalInteger(
+        RING_GROUP_CONDUCTOR_SECTION_KEY,
+        AVAILABILITY_BUCKET_MIN_SERVING_REPLICAS
+    );
+
+    if(minServingReplicas == null){
+      return DEFAULT_MIN_SERVING_REPLICAS;
+    }
+
+    return minServingReplicas;
   }
 
   @Override

--- a/hank-server/src/main/java/com/liveramp/hank/ring_group_conductor/RingGroupConductor.java
+++ b/hank-server/src/main/java/com/liveramp/hank/ring_group_conductor/RingGroupConductor.java
@@ -1,23 +1,24 @@
 /**
- *  Copyright 2011 LiveRamp
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Copyright 2011 LiveRamp
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.liveramp.hank.ring_group_conductor;
 
 import java.io.IOException;
 
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.log4j.PropertyConfigurator;
 
 import com.liveramp.hank.config.RingGroupConductorConfigurator;
@@ -46,7 +47,12 @@ public class RingGroupConductor {
   private Thread shutdownHook;
 
   public RingGroupConductor(RingGroupConductorConfigurator configurator) throws IOException {
-    this(configurator, new RingGroupUpdateTransitionFunctionImpl(new RendezVousPartitionAssigner(), configurator.getMinRingFullyServingObservations()));
+    this(configurator, new RingGroupUpdateTransitionFunctionImpl(new RendezVousPartitionAssigner(),
+        configurator.getMinRingFullyServingObservations(),
+        configurator.getMinServingReplicas(),
+        configurator.getAvailabilityBucketMinServingReplicas(),
+        configurator.getHostAvailabilityBucketFlag()
+    ));
   }
 
   RingGroupConductor(RingGroupConductorConfigurator configurator, RingGroupUpdateTransitionFunction transFunc) throws IOException {

--- a/hank-server/src/main/java/com/liveramp/hank/ring_group_conductor/RingGroupUpdateTransitionFunctionImpl.java
+++ b/hank-server/src/main/java/com/liveramp/hank/ring_group_conductor/RingGroupUpdateTransitionFunctionImpl.java
@@ -1,28 +1,36 @@
 /**
- *  Copyright 2011 LiveRamp
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Copyright 2011 LiveRamp
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.liveramp.hank.ring_group_conductor;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.liveramp.hank.coordinator.Domain;
 import com.liveramp.hank.coordinator.DomainAndVersion;
@@ -43,12 +51,21 @@ public class RingGroupUpdateTransitionFunctionImpl implements RingGroupUpdateTra
 
   private final PartitionAssigner partitionAssigner;
   private final int minRingFullyServingObservations;
+  private final int minServingReplicas;
+  private final int minServingAvailabilityBucketReplicas;
+  private final String availablilityBucketKey;
   private final Map<String, Integer> hostToFullyServingObservations = new HashMap<String, Integer>();
 
   public RingGroupUpdateTransitionFunctionImpl(PartitionAssigner partitionAssigner,
-                                               int minRingFullyServingObservations) throws IOException {
+                                               int minRingFullyServingObservations,
+                                               int minServingReplicas,
+                                               int minServingAvailabilityBucketReplicas,
+                                               String availablilityBucketKey) throws IOException {
     this.partitionAssigner = partitionAssigner;
     this.minRingFullyServingObservations = minRingFullyServingObservations;
+    this.minServingReplicas = minServingReplicas;
+    this.minServingAvailabilityBucketReplicas = minServingAvailabilityBucketReplicas;
+    this.availablilityBucketKey = availablilityBucketKey;
   }
 
   private static boolean isServingAndAboutToServe(Host host) throws IOException {
@@ -97,26 +114,20 @@ public class RingGroupUpdateTransitionFunctionImpl implements RingGroupUpdateTra
       return;
     }
 
-    int minNumReplicasFullyServing;
-    if (ringGroup.getRings().size() <= 3) {
-      minNumReplicasFullyServing = ringGroup.getRings().size() - 1;
-    } else {
-      minNumReplicasFullyServing = ringGroup.getRings().size() - 2;
-    }
+    int numRingGroups = ringGroup.getRings().size();
 
     Map<Domain, Map<Integer, Set<Host>>> domainToPartitionToHostsFullyServing = computeDomainToPartitionToHostsFullyServing(ringGroup);
 
     for (Ring ring : ringGroup.getRingsSorted()) {
       partitionAssigner.prepare(ring, domainGroup.getDomainVersions(), ringGroup.getRingGroupConductorMode());
       for (Host host : ring.getHostsSorted()) {
-        manageTransitions(host, domainGroup, minNumReplicasFullyServing, domainToPartitionToHostsFullyServing);
+        manageTransitions(host, domainGroup, domainToPartitionToHostsFullyServing);
       }
     }
   }
 
   private void manageTransitions(Host host,
                                  DomainGroup domainGroup,
-                                 int minNumReplicasFullyServing,
                                  Map<Domain, Map<Integer, Set<Host>>> domainToPartitionToHostsFullyServing) throws IOException {
     boolean isAssigned = partitionAssigner.isAssigned(host);
     boolean isUpToDate = Hosts.isUpToDate(host, domainGroup);
@@ -130,13 +141,13 @@ public class RingGroupUpdateTransitionFunctionImpl implements RingGroupUpdateTra
 
     // Note: numReplicasFullyServing can be null if the host is not serving relevant data
 
-    Integer numReplicasFullyServing =
-        computeNumReplicasFullyServingRelevantData(
+    LiveReplicaStatus status =
+        computeDataReplicationStatus(
             domainToPartitionToHostsFullyServing,
             domainGroup.getDomainVersions(),
             host);
-    if (numReplicasFullyServing == null) {
-      numReplicasFullyServing = Integer.MAX_VALUE;
+    if (status == null) {
+      status = LiveReplicaStatus.OVER_REPLICATED;
     }
 
     // Not enough replicas are fully serving and the current host is servable. Serve.
@@ -233,9 +244,22 @@ public class RingGroupUpdateTransitionFunctionImpl implements RingGroupUpdateTra
     return result;
   }
 
-  private Integer computeNumReplicasFullyServingRelevantData(Map<Domain, Map<Integer, Set<Host>>> domainToPartitionToHostsFullyServing,
-                                                             Set<DomainAndVersion> domainVersions,
-                                                             Host host) throws IOException {
+  enum LiveReplicaStatus {
+    UNDER_REPLICATED,
+    REPLICATED,
+    OVER_REPLICATED;
+
+    public static LiveReplicaStatus min(LiveReplicaStatus... statuses) {
+      return LiveReplicaStatus.values()[Collections.min(Lists.newArrayList(statuses)
+          .stream()
+          .map(input -> input.ordinal())
+          .collect(Collectors.toList()))];
+    }
+  }
+
+  private LiveReplicaStatus computeDataReplicationStatus(Map<Domain, Map<Integer, Set<Host>>> domainToPartitionToHostsFullyServing,
+                                                         Set<DomainAndVersion> domainVersions,
+                                                         Host host) throws IOException {
     // Build set of relevant domains
     Set<Domain> relevantDomains = new HashSet<Domain>();
     for (DomainAndVersion domainVersion : domainVersions) {
@@ -244,26 +268,57 @@ public class RingGroupUpdateTransitionFunctionImpl implements RingGroupUpdateTra
 
     // Compute num replicas fully serving for given host, which is the minimum of the number of replicas
     // fully serving across all partitions assigned to it (for relevant domains)
-    Integer result = null;
+    LiveReplicaStatus worstStatus = LiveReplicaStatus.OVER_REPLICATED;
+
     for (HostDomain hostDomain : host.getAssignedDomains()) {
       Domain domain = hostDomain.getDomain();
       // Only consider relevant domains
       if (relevantDomains.contains(domain)) {
         Map<Integer, Set<Host>> partitionToNumFullyServing = domainToPartitionToHostsFullyServing.get(hostDomain.getDomain());
         if (partitionToNumFullyServing == null) {
-          return 0;
+          return LiveReplicaStatus.UNDER_REPLICATED;
         }
         for (HostDomainPartition partition : hostDomain.getPartitions()) {
-          int numFullyServing = 0;
           if (partitionToNumFullyServing.containsKey(partition.getPartitionNumber())) {
-            numFullyServing = partitionToNumFullyServing.get(partition.getPartitionNumber()).size();
-          }
-          if (result == null || numFullyServing < result) {
-            result = numFullyServing;
+
+            Set<Host> servingHosts = partitionToNumFullyServing.get(partition.getPartitionNumber());
+            worstStatus = LiveReplicaStatus.min(
+                worstStatus,
+                statusFor(servingHosts.size(), minServingReplicas),
+                statusFor(
+                    (int)servingHosts.stream().filter(input -> sameBucket(host, input)).count(),
+                    minServingAvailabilityBucketReplicas
+                )
+            );
+
           }
         }
       }
     }
-    return result;
+    return worstStatus;
+  }
+
+  private LiveReplicaStatus statusFor(int numServing, int numRequired) {
+    if (numServing < numRequired) {
+      return LiveReplicaStatus.UNDER_REPLICATED;
+    }
+
+    if (numServing == numRequired) {
+      return LiveReplicaStatus.REPLICATED;
+    }
+
+    return LiveReplicaStatus.OVER_REPLICATED;
+  }
+
+  private boolean sameBucket(Host host1, Host host2) {
+    if (availablilityBucketKey == null) {
+      return true;
+    }
+
+    return Objects.equals(
+        host1.getEnvironmentFlags().get(availablilityBucketKey),
+        host2.getEnvironmentFlags().get(availablilityBucketKey)
+    );
+
   }
 }

--- a/hank-server/src/test/java/com/liveramp/hank/IntegrationTest.java
+++ b/hank-server/src/test/java/com/liveramp/hank/IntegrationTest.java
@@ -125,6 +125,7 @@ public class IntegrationTest extends ZkTestCase {
       pw.println("  " + YamlRingGroupConductorConfigurator.MIN_RING_FULLY_SERVING_OBSERVATIONS_KEY + ": 5");
       pw.println("  " + YamlRingGroupConductorConfigurator.RING_GROUP_NAME_KEY + ": rg1");
       pw.println("  " + YamlRingGroupConductorConfigurator.INITIAL_MODE_KEY + ": ACTIVE");
+      pw.println("  " + YamlRingGroupConductorConfigurator.MIN_SERVING_REPLICAS + ": 1"); //  only have 2x2 servers
       coordinatorConfig(pw);
       pw.close();
       configurator = new YamlRingGroupConductorConfigurator(configPath);
@@ -210,7 +211,10 @@ public class IntegrationTest extends ZkTestCase {
 
   @Test
   public void testItAll() throws Throwable {
-    org.apache.log4j.Logger.getLogger("com.liveramp.hank.coordinator.zk").setLevel(Level.INFO);
+    org.apache.log4j.Logger.getLogger("com.liveramp.hank.coordinator.zk").setLevel(Level.WARN);
+    org.apache.log4j.Logger.getLogger("org.apache.zookeeper").setLevel(Level.WARN);
+    org.apache.log4j.Logger.getLogger("org.apache.zookeeper.server").setLevel(Level.WARN);
+
     // Logger.getLogger("com.liveramp.hank.partition_server").setLevel(Level.INFO);
     org.apache.log4j.Logger.getLogger("com.liveramp.hank.storage").setLevel(Level.TRACE);
     create(domainsRoot);

--- a/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestRingGroupConductor.java
+++ b/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestRingGroupConductor.java
@@ -134,6 +134,21 @@ public class TestRingGroupConductor {
       }
 
       @Override
+      public String getHostAvailabilityBucketFlag() {
+        return null;
+      }
+
+      @Override
+      public int getMinServingReplicas() {
+        return 2;
+      }
+
+      @Override
+      public int getAvailabilityBucketMinServingReplicas() {
+        return 0;
+      }
+
+      @Override
       public String getRingGroupName() {
         return "myRingGroup";
       }

--- a/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestRingGroupUpdateTransitionFunctionImpl.java
+++ b/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestRingGroupUpdateTransitionFunctionImpl.java
@@ -17,6 +17,7 @@ package com.liveramp.hank.ring_group_conductor;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -674,4 +675,80 @@ public class TestRingGroupUpdateTransitionFunctionImpl extends BaseTestCase {
     assertNull(r2h0.getAndClearLastEnqueuedCommand());
     assertNull(r2h1.getAndClearLastEnqueuedCommand());
   }
+
+  //  2 - 2 : doesn't update both in either AZ
+
+  @Test
+  public void testSingleUpdateSameBucket() throws IOException {
+    domainGroup.setDomainVersions(versionsMap2);
+
+    r0h0.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+    r0h1.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+
+    r1h0.setEnvironmentFlags(Collections.singletonMap("AZ", "b"));
+    r1h1.setEnvironmentFlags(Collections.singletonMap("AZ", "b"));
+
+    r2h0.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+    r2h1.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+
+    //  all rings need to be updated
+    setUpRing(r0, v1, v2, HostState.SERVING);
+    setUpRing(r1, v1, v2, HostState.SERVING);
+    setUpRing(r2, v1, v2, HostState.SERVING);
+
+    //  require at least 1 replica up per AZ.
+    testTransitionFunction = new RingGroupUpdateTransitionFunctionImpl(partitionAssigner, 0, 1, 1, "AZ");
+    testTransitionFunction.manageTransitions(rg);
+
+    //  r0 can go idle
+    assertEquals(HostCommand.GO_TO_IDLE, r0h0.getAndClearLastEnqueuedCommand());
+    assertEquals(HostCommand.GO_TO_IDLE, r0h1.getAndClearLastEnqueuedCommand());
+
+    //  r1 can't
+    assertEquals(null, r1h0.getAndClearLastEnqueuedCommand());
+    assertEquals(null, r1h1.getAndClearLastEnqueuedCommand());
+
+    //  r2 can't
+    assertEquals(null, r2h0.getAndClearLastEnqueuedCommand());
+    assertEquals(null, r2h1.getAndClearLastEnqueuedCommand());
+
+  }
+
+  @Test
+  public void testUpdateWithNoMin() throws IOException {
+    domainGroup.setDomainVersions(versionsMap2);
+
+    r0h0.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+    r0h1.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+
+    r1h0.setEnvironmentFlags(Collections.singletonMap("AZ", "b"));
+    r1h1.setEnvironmentFlags(Collections.singletonMap("AZ", "b"));
+
+    r2h0.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+    r2h1.setEnvironmentFlags(Collections.singletonMap("AZ", "a"));
+
+    //  all rings need to be updated
+    setUpRing(r0, v1, v2, HostState.SERVING);
+    setUpRing(r1, v1, v2, HostState.SERVING);
+    setUpRing(r2, v1, v2, HostState.SERVING);
+
+    //  no minimum number of replicas per zone
+    testTransitionFunction = new RingGroupUpdateTransitionFunctionImpl(partitionAssigner, 0, 1, 0, "AZ");
+    testTransitionFunction.manageTransitions(rg);
+
+    //  r0 can go idle
+    assertEquals(HostCommand.GO_TO_IDLE, r0h0.getAndClearLastEnqueuedCommand());
+    assertEquals(HostCommand.GO_TO_IDLE, r0h1.getAndClearLastEnqueuedCommand());
+
+    //  r1 can as well, since 0 min
+    assertEquals(HostCommand.GO_TO_IDLE, r1h0.getAndClearLastEnqueuedCommand());
+    assertEquals(HostCommand.GO_TO_IDLE, r1h1.getAndClearLastEnqueuedCommand());
+
+    //  r2 can't, limited by global 1 min replica.
+    assertEquals(null, r2h0.getAndClearLastEnqueuedCommand());
+    assertEquals(null, r2h1.getAndClearLastEnqueuedCommand());
+
+  }
+
+
 }

--- a/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestRingGroupUpdateTransitionFunctionImpl.java
+++ b/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestRingGroupUpdateTransitionFunctionImpl.java
@@ -146,7 +146,7 @@ public class TestRingGroupUpdateTransitionFunctionImpl extends BaseTestCase {
 
     partitionAssigner = new ModPartitionAssigner();
 
-    testTransitionFunction = new RingGroupUpdateTransitionFunctionImpl(partitionAssigner, 0);
+    testTransitionFunction = new RingGroupUpdateTransitionFunctionImpl(partitionAssigner, 0, 2, 0, null);
 
     // V1
     versionsMap1.put(domain1, 1);
@@ -188,7 +188,7 @@ public class TestRingGroupUpdateTransitionFunctionImpl extends BaseTestCase {
 
   @Test
   public void testIsFullyServing() throws IOException {
-    RingGroupUpdateTransitionFunctionImpl transitionFunction = new RingGroupUpdateTransitionFunctionImpl(null, 1);
+    RingGroupUpdateTransitionFunctionImpl transitionFunction = new RingGroupUpdateTransitionFunctionImpl(null, 1, 2, 0, null);
 
     setUpRing(r0, v1, v1, HostState.IDLE);
     assertFalse(transitionFunction.isFullyServing(r0h0, true));

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>hank</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.1-AZ-LOCALITY-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>hank</artifactId>
-  <version>1.1-AZ-LOCALITY-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
I'm putting this up as a separate PR from the client locality for clarity, but it's built on top of that code.  The idea here is to prevent the RingGroupConductor from taking down all replicas within an AZ for updates at once.  So now there are two different parameters for replication requirements:

min_serving_replicas -- total replicas which must be live
availability_bucket_min_serving_replicas -- total replicas within a bucket (eg availability zone) which must be live

for min_serving_replicas we'll probably use the same as before (2), meaning, we want 2 replicas of the data at any time.  for availability_bucket_min_serving_replicas I think we probably only want 1; it's not the end of the world to fall back to a different AZ temporarily if a server fails.

been testing on AWS and seems to work.  should not change any existing behavior if there is no host_availability_bucket is specified (eg in colo)

@michel-tricot @roshan @sidoh 