### PR TITLE
Shut down UI on ZK session expiry.  Sweep old broken reconnect logic.

### DIFF
--- a/hank-core/src/main/java/com/liveramp/hank/coordinator/Coordinator.java
+++ b/hank-core/src/main/java/com/liveramp/hank/coordinator/Coordinator.java
@@ -79,4 +79,10 @@ public interface Coordinator {
   //  this kinda breaks the interface, but I want a way to let the UI know that zookeeper isn't connected
   public String getDataState() throws IOException;
 
+  public interface StateChangeListener {
+    public void process(String newState);
+  }
+
+  public void addDataStateChangeListener(StateChangeListener listener);
+
 }

--- a/hank-core/src/main/java/com/liveramp/hank/coordinator/mock/MockCoordinator.java
+++ b/hank-core/src/main/java/com/liveramp/hank/coordinator/mock/MockCoordinator.java
@@ -173,6 +173,11 @@ public class MockCoordinator implements Coordinator {
   }
 
   @Override
+  public void addDataStateChangeListener(StateChangeListener listener) {
+    //  no-op
+  }
+
+  @Override
   public Set<RingGroup> getRingGroupsForDomainGroup(DomainGroup domainGroup) {
     return null;
   }

--- a/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZooKeeperCoordinator.java
+++ b/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZooKeeperCoordinator.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import com.google.common.collect.Lists;
 import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;

--- a/hank-core/src/main/java/com/liveramp/hank/test/CoreConfigFixtures.java
+++ b/hank-core/src/main/java/com/liveramp/hank/test/CoreConfigFixtures.java
@@ -1,0 +1,56 @@
+package com.liveramp.hank.test;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.UUID;
+
+import com.liveramp.hank.config.CoordinatorConfigurator;
+import com.liveramp.hank.config.InvalidConfigurationException;
+import com.liveramp.hank.config.yaml.YamlCoordinatorConfigurator;
+import com.liveramp.hank.coordinator.Coordinator;
+
+public class CoreConfigFixtures {
+
+  public static String coordinatorConfig(int zkPort,
+                                         int sessionTimeout,
+                                         String domainsRoot,
+                                         String domainGroupsRoot,
+                                         String ringGroupsRoot) {
+
+    StringBuilder builder = new StringBuilder();
+
+    builder.append(
+        "coordinator:\n" +
+            "  factory: com.liveramp.hank.coordinator.zk.ZooKeeperCoordinator$Factory\n" +
+            "  options:\n" +
+            "    connect_string: localhost:").append(zkPort).append("\n")
+        .append("    session_timeout: "+sessionTimeout+"\n");
+    builder.append("    domains_root: ").append(domainsRoot).append("\n");
+    builder.append("    domain_groups_root: ").append(domainGroupsRoot).append("\n");
+    builder.append("    ring_groups_root: ").append(ringGroupsRoot).append("\n");
+    builder.append("    max_connection_attempts: 5\n");
+
+    return builder.toString();
+  }
+
+  public static Coordinator createCoordinator(String tmpDir,
+                                              int zkPort,
+                                              int sessionTimeout,
+                                              String domainsRoot,
+                                              String domainGroupsRoot,
+                                              String ringGroupsRoot) throws IOException, InvalidConfigurationException {
+
+    String tmpFile = tmpDir + "/" + UUID.randomUUID().toString();
+
+    FileWriter fileWriter = new FileWriter(tmpFile);
+    fileWriter.append(coordinatorConfig(zkPort, sessionTimeout, domainsRoot, domainGroupsRoot, ringGroupsRoot));
+    fileWriter.close();
+
+    CoordinatorConfigurator config = new YamlCoordinatorConfigurator(tmpFile);
+
+    return config.createCoordinator();
+
+  }
+
+
+}

--- a/hank-core/src/main/java/com/liveramp/hank/test/ZkTestCase.java
+++ b/hank-core/src/main/java/com/liveramp/hank/test/ZkTestCase.java
@@ -1,17 +1,17 @@
 /**
- *  Copyright 2011 LiveRamp
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Copyright 2011 LiveRamp
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.liveramp.hank.test;
 
@@ -70,12 +70,33 @@ public abstract class ZkTestCase extends BaseTestCase {
     zkRoot = "/" + getClass().getSimpleName();
   }
 
+
+  public static void shutdownZkServer() throws Exception {
+    if (server != null) {
+      server.shutdown();
+
+      standaloneServerFactory.shutdown();
+      standaloneServerFactory = null;
+
+      server = null;
+    }
+  }
+
+  public static void expireSession(long sessionId){
+    server.closeSession(sessionId);
+  }
+
+  @Before
+  public void clearZkDir() throws IOException {
+    LOG.debug("deleting zk data dir (" + zkDir + ")");
+    File zkDirFile = new File(zkDir);
+    FileUtils.deleteDirectory(zkDirFile);
+    zkDirFile.mkdirs();
+  }
+
   public static void setupZkServer() throws Exception {
     if (server == null) {
-      LOG.debug("deleting zk data dir (" + zkDir + ")");
       File zkDirFile = new File(zkDir);
-      FileUtils.deleteDirectory(zkDirFile);
-      zkDirFile.mkdirs();
 
       server = new ZooKeeperServer(zkDirFile, zkDirFile, TICK_TIME);
 
@@ -127,7 +148,6 @@ public abstract class ZkTestCase extends BaseTestCase {
         LOG.debug(event.toString());
       }
     });
-    zk.reconnect();
 
     synchronized (lock) {
       lock.wait(2000);
@@ -260,7 +280,7 @@ public abstract class ZkTestCase extends BaseTestCase {
   }
 
   protected void create(String path) throws Exception {
-    create(path, (byte[]) null);
+    create(path, (byte[])null);
   }
 
   protected void create(String path, String data) throws Exception {

--- a/hank-core/src/main/java/com/liveramp/hank/zookeeper/ZooKeeperPlus.java
+++ b/hank-core/src/main/java/com/liveramp/hank/zookeeper/ZooKeeperPlus.java
@@ -1,17 +1,17 @@
 /**
- *  Copyright 2011 LiveRamp
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Copyright 2011 LiveRamp
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.liveramp.hank.zookeeper;
@@ -32,379 +32,143 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ZooKeeperPlus {
+public class ZooKeeperPlus extends ZooKeeper {
   private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperPlus.class);
 
   private static final List<ACL> DEFAULT_ACL = Ids.OPEN_ACL_UNSAFE;
   private static final CreateMode DEFAULT_CREATE_MODE = CreateMode.PERSISTENT;
 
-  private ZKPCore conn;
-
-  private final String reconnectString;
-  private final int sessionTimeout;
-  private final Watcher watcher;
-  private final Thread reconnectWatcher;
-
-  public ZooKeeperPlus(String reconnectString, int sessionTimeout, Watcher watcher){
-    this.reconnectString = reconnectString;
-    this.sessionTimeout = sessionTimeout;
-    this.watcher = watcher;
-
-    this.reconnectWatcher = new Thread(new ReconnectWatcher());
-    this.reconnectWatcher.setDaemon(true);
-    this.reconnectWatcher.start();
+  public ZooKeeperPlus(String connectString,
+                       int sessionTimeout,
+                       Watcher watcher,
+                       long sessionId,
+                       byte[] sessionPasswd) throws IOException {
+    super(connectString, sessionTimeout, watcher, sessionId, sessionPasswd);
   }
 
-  public synchronized void reconnect() throws IOException {
-    conn = new ZKPCore(reconnectString, sessionTimeout, watcher);
-  }
-
-  public class ReconnectWatcher implements Runnable {
-
-    private static final long POLL_INTERVAL = 30000;  // 30s
-
-    @Override
-    public void run() {
-
-      try {
-
-        while(true) {
-          Thread.sleep(POLL_INTERVAL);
-          //  don't start reconnect until we explicitly connect for the first time
-          if (conn != null && conn.getState() != ZooKeeper.States.CONNECTED) {
-            LOG.info("ZooKeeper is not connected.  Closing connection");
-            close();
-            try {
-              LOG.info("Reconnecting");
-              reconnect();
-              LOG.info("Reconnected");
-            } catch (IOException e) {
-              LOG.error("Error reconnecting to ZooKeeper", e);
-            }
-          }else{
-            LOG.info("ZooKeeper is connected, sleeping for "+POLL_INTERVAL+"ms");
-          }
-        }
-
-      } catch (InterruptedException e) {
-        LOG.error("Interrupting watcher sleep", e);
-      }
-
-    }
-
-  }
-
-  public void create(String path, byte[] data, CreateMode createMode) throws KeeperException, InterruptedException {
-    conn.create(path, data, createMode);
-  }
-
-  public void create(String path, byte[] data) throws KeeperException, InterruptedException {
-    conn.create(path, data);
-  }
-
-  public String create(final String path, byte data[], List<ACL> acl, CreateMode createMode) throws KeeperException, InterruptedException{
-    return conn.create(path, data, acl, createMode);
-  }
-
-  public void create(final String path, byte data[], List<ACL> acl, CreateMode createMode,  AsyncCallback.StringCallback cb, Object ctx){
-    conn.create(path, data, acl, createMode, cb, ctx);
-
-  }
-
-
-  public void createLong(String path, long value) throws KeeperException, InterruptedException {
-    conn.createLong(path, value);
-  }
-
-  public void createInt(String path, int value) throws KeeperException, InterruptedException {
-    conn.createInt(path, value);
-  }
-
-  public Integer getIntOrNull(String path) throws KeeperException, InterruptedException {
-    return conn.getIntOrNull(path);
-  }
-
-  public int getInt(String path) throws KeeperException, InterruptedException {
-    return conn.getInt(path);
-  }
-
-  public void setString(String path, String value) throws KeeperException, InterruptedException {
-    conn.setString(path, value);
-  }
-
-  public void setInt(String path, int nextVersion) throws KeeperException, InterruptedException {
-    conn.setInt(path, nextVersion);
+  public ZooKeeperPlus(String connectString, int sessionTimeout, Watcher watcher) throws IOException {
+    super(connectString, sessionTimeout, watcher);
   }
 
   public long getLong(String path) throws KeeperException, InterruptedException {
-    return conn.getLong(path);
+    return Long.parseLong(new String(getData(path, false, new Stat())));
   }
 
+
   public Long getLongOrNull(String path) throws KeeperException, InterruptedException {
-    return conn.getLongOrNull(path);
+    if (exists(path, false) == null) {
+      return null;
+    } else {
+      return Long.parseLong(new String(getData(path, false, new Stat())));
+    }
   }
 
   public String getString(String path) throws KeeperException, InterruptedException {
-    return conn.getString(path);
+    try {
+      byte[] data = getData(path, false, null);
+      if (data == null) {
+        return null;
+      }
+      return new String(data, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public void deleteIfExists(String path) throws KeeperException, InterruptedException {
-    conn.deleteIfExists(path);
+    if (exists(path, false) != null) {
+      delete(path, -1);
+    }
   }
 
   public void setOrCreate(String path, int value, CreateMode createMode) throws KeeperException, InterruptedException {
-    conn.setOrCreate(path, value, createMode);
+    setOrCreate(path, Integer.toString(value), createMode);
   }
 
   public void setOrCreate(String path, long value, CreateMode createMode) throws KeeperException, InterruptedException {
-    conn.setOrCreate(path, value, createMode);
+    setOrCreate(path, Long.toString(value), createMode);
   }
 
   public void setOrCreate(String path, String value, CreateMode createMode) throws KeeperException, InterruptedException {
-    conn.setOrCreate(path, value, createMode);
+    if (exists(path, false) == null) {
+      create(path, value.getBytes(), DEFAULT_ACL, createMode);
+    } else {
+      setData(path, value.getBytes(), -1);
+    }
   }
 
   public void ensureCreated(String path, byte[] value) throws InterruptedException, KeeperException {
-    conn.ensureCreated(path, value);
+    ensureCreated(path, value, DEFAULT_CREATE_MODE);
   }
 
   public void ensureCreated(String path, byte[] value, CreateMode createMode) throws InterruptedException, KeeperException {
-    conn.ensureCreated(path, value, createMode);
+    if (!path.isEmpty() && exists(path, false) == null) {
+      ensureCreated(new File(path).getParent(), null, createMode);
+      create(path, value, DEFAULT_ACL, createMode);
+      NodeCreationBarrier.block(ZooKeeperPlus.this, path);
+    }
   }
 
   public void deleteNodeRecursively(String path) throws InterruptedException, KeeperException {
-    conn.deleteNodeRecursively(path);
+    try {
+      delete(path, -1);
+    } catch (KeeperException.NotEmptyException e) {
+      List<String> children = getChildren(path, null);
+      for (String child : children) {
+        deleteNodeRecursively(ZkPath.append(path, child));
+      }
+      delete(path, -1);
+    } catch (KeeperException.NoNodeException e) {
+      // Silently return if the node has already been deleted.
+      return;
+    }
   }
 
   // Get not hidden children (children that do not start with a period)
   public List<String> getChildrenNotHidden(String path, boolean watch) throws InterruptedException, KeeperException {
-    return conn.getChildrenNotHidden(path, watch);
+    return ZkPath.filterOutHiddenPaths(super.getChildren(path, watch));
   }
 
   public List<String> getChildrenNotHidden(String path, Watcher watcher) throws InterruptedException, KeeperException {
-    return conn.getChildrenNotHidden(path, watcher);
-  }
-
-  public int getSessionTimeout() {
-    return conn.getSessionTimeout();
-  }
-
-  public List<String> getChildren(final String path, Watcher watcher) throws KeeperException, InterruptedException {
-    return conn.getChildren(path, watcher);
-  }
-
-  public Stat exists(String path, boolean watch) throws KeeperException, InterruptedException {
-    return conn.exists(path, watch);
-  }
-
-  public void exists(final String path, Watcher watcher, AsyncCallback.StatCallback cb, Object ctx) {
-    conn.exists(path, watcher, cb, ctx);
-  }
-
-  public void exists(String path, boolean watch, AsyncCallback.StatCallback cb, Object ctx) {
-    conn.exists(path, watch, cb, ctx);
-  }
-
-  public Stat exists(final String path, Watcher watcher) throws KeeperException, InterruptedException {
-    return conn.exists(path, watcher);
+    return ZkPath.filterOutHiddenPaths(super.getChildren(path, watcher));
   }
 
 
-  public List<String> getChildren(String path, boolean watch) throws KeeperException, InterruptedException {
-    return conn.getChildrenNotHidden(path, watch);
+  public void create(String path, byte[] data, CreateMode createMode) throws KeeperException, InterruptedException {
+    create(path, data, DEFAULT_ACL, createMode);
   }
 
-  public void getChildren(final String path, Watcher watcher, AsyncCallback.ChildrenCallback cb, Object ctx) {
-    conn.getChildren(path, watcher, cb, ctx);
+  public void create(String path, byte[] data) throws KeeperException, InterruptedException {
+    create(path, data, DEFAULT_ACL, DEFAULT_CREATE_MODE);
   }
 
-  public void getChildren(String path, boolean watch, AsyncCallback.ChildrenCallback cb, Object ctx) {
-    conn.getChildren(path, watch, cb, ctx);
+  public void createLong(String path, long value) throws KeeperException, InterruptedException {
+    create(path, (Long.toString(value)).getBytes(), DEFAULT_ACL, DEFAULT_CREATE_MODE);
   }
 
-  public List<String> getChildren(final String path, Watcher watcher, Stat stat) throws KeeperException, InterruptedException {
-    return conn.getChildren(path, watcher, stat);
+  public void createInt(String path, int value) throws KeeperException, InterruptedException {
+    create(path, (Integer.toString(value)).getBytes(), DEFAULT_ACL, DEFAULT_CREATE_MODE);
   }
 
-  public List<String> getChildren(String path, boolean watch, Stat stat) throws KeeperException, InterruptedException {
-    return conn.getChildren(path, watch, stat);
-  }
-
-  public void getChildren(final String path, Watcher watcher, AsyncCallback.Children2Callback cb, Object ctx) {
-    conn.getChildren(path, watcher, cb, ctx);
-  }
-
-  public void getChildren(String path, boolean watch, AsyncCallback.Children2Callback cb, Object ctx) {
-    conn.getChildren(path, watch, cb, ctx);
-  }
-
-  public void delete(final String path, int version) throws InterruptedException, KeeperException {
-    conn.delete(path, version);
-  }
-
-  public void getData(String path, boolean watch, AsyncCallback.DataCallback cb, Object ctx) {
-    conn.getData(path, watch, cb, ctx);
-  }
-
-  public byte[] getData(String path, boolean watch, Stat stat) throws KeeperException, InterruptedException {
-    return conn.getData(path, watch, stat);
-  }
-
-  public void getData(final String path, Watcher watcher, AsyncCallback.DataCallback cb, Object ctx) {
-    conn.getData(path, watcher, cb, ctx);
-  }
-
-  public byte[] getData(final String path, Watcher watcher, Stat stat) throws KeeperException, InterruptedException {
-    return conn.getData(path, watcher, stat);
-  }
-
-  public Stat setData(final String path, byte data[], int version) throws KeeperException, InterruptedException {
-    return conn.setData(path, data, version);
-  }
-
-  public void setData(final String path, byte data[], int version, AsyncCallback.StatCallback cb, Object ctx){
-    conn.setData(path, data, version, cb, ctx);
-  }
-
-  public synchronized void close() throws InterruptedException {
-    conn.close();
-    reconnectWatcher.interrupt();
-  }
-
-  public ZooKeeper.States getState() {
-    return conn.getState();
-  }
-
-  private class ZKPCore extends ZooKeeper {
-
-    private ZKPCore(String connectString,
-                    int sessionTimeout,
-                    Watcher watcher,
-                    long sessionId,
-                    byte[] sessionPasswd) throws IOException {
-      super(connectString, sessionTimeout, watcher, sessionId, sessionPasswd);
+  public Integer getIntOrNull(String path) throws KeeperException, InterruptedException {
+    Long lvalue = getLongOrNull(path);
+    if (lvalue == null) {
+      return null;
     }
-
-    private ZKPCore(String connectString, int sessionTimeout, Watcher watcher) throws IOException {
-      super(connectString, sessionTimeout, watcher);
-    }
-
-    public void create(String path, byte[] data, CreateMode createMode) throws KeeperException, InterruptedException {
-      create(path, data, DEFAULT_ACL, createMode);
-    }
-
-    public void create(String path, byte[] data) throws KeeperException, InterruptedException {
-      create(path, data, DEFAULT_ACL, DEFAULT_CREATE_MODE);
-    }
-
-    public void createLong(String path, long value) throws KeeperException, InterruptedException {
-      create(path, (Long.toString(value)).getBytes(), DEFAULT_ACL, DEFAULT_CREATE_MODE);
-    }
-
-    public void createInt(String path, int value) throws KeeperException, InterruptedException {
-      create(path, (Integer.toString(value)).getBytes(), DEFAULT_ACL, DEFAULT_CREATE_MODE);
-    }
-
-    public Integer getIntOrNull(String path) throws KeeperException, InterruptedException {
-      Long lvalue = getLongOrNull(path);
-      if (lvalue == null) {
-        return null;
-      }
-      return lvalue.intValue();
-    }
-
-    public int getInt(String path) throws KeeperException, InterruptedException {
-      return Integer.parseInt(new String(getData(path, false, new Stat())));
-    }
-
-    public void setString(String path, String value) throws KeeperException, InterruptedException {
-      setData(path, value.getBytes(), -1);
-    }
-
-    public void setInt(String path, int nextVersion) throws KeeperException, InterruptedException {
-      setData(path, (Integer.toString(nextVersion)).getBytes(), -1);
-    }
-
-    public long getLong(String path) throws KeeperException, InterruptedException {
-      return Long.parseLong(new String(getData(path, false, new Stat())));
-    }
-
-    public Long getLongOrNull(String path) throws KeeperException, InterruptedException {
-      if (exists(path, false) == null) {
-        return null;
-      } else {
-        return Long.parseLong(new String(getData(path, false, new Stat())));
-      }
-    }
-
-    public String getString(String path) throws KeeperException, InterruptedException {
-      try {
-        byte[] data = getData(path, false, null);
-        if (data == null) {
-          return null;
-        }
-        return new String(data, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    public void deleteIfExists(String path) throws KeeperException, InterruptedException {
-      if (exists(path, false) != null) {
-        delete(path, -1);
-      }
-    }
-
-    public void setOrCreate(String path, int value, CreateMode createMode) throws KeeperException, InterruptedException {
-      setOrCreate(path, Integer.toString(value), createMode);
-    }
-
-    public void setOrCreate(String path, long value, CreateMode createMode) throws KeeperException, InterruptedException {
-      setOrCreate(path, Long.toString(value), createMode);
-    }
-
-    public void setOrCreate(String path, String value, CreateMode createMode) throws KeeperException, InterruptedException {
-      if (exists(path, false) == null) {
-        create(path, value.getBytes(), DEFAULT_ACL, createMode);
-      } else {
-        setData(path, value.getBytes(), -1);
-      }
-    }
-
-    public void ensureCreated(String path, byte[] value) throws InterruptedException, KeeperException {
-      ensureCreated(path, value, DEFAULT_CREATE_MODE);
-    }
-
-    public void ensureCreated(String path, byte[] value, CreateMode createMode) throws InterruptedException, KeeperException {
-      if (!path.isEmpty() && exists(path, false) == null) {
-        ensureCreated(new File(path).getParent(), null, createMode);
-        create(path, value, DEFAULT_ACL, createMode);
-        NodeCreationBarrier.block(ZooKeeperPlus.this, path);
-      }
-    }
-
-    public void deleteNodeRecursively(String path) throws InterruptedException, KeeperException {
-      try {
-        delete(path, -1);
-      } catch (KeeperException.NotEmptyException e) {
-        List<String> children = getChildren(path, null);
-        for (String child : children) {
-          deleteNodeRecursively(ZkPath.append(path, child));
-        }
-        delete(path, -1);
-      } catch (KeeperException.NoNodeException e) {
-        // Silently return if the node has already been deleted.
-        return;
-      }
-    }
-
-    // Get not hidden children (children that do not start with a period)
-    public List<String> getChildrenNotHidden(String path, boolean watch) throws InterruptedException, KeeperException {
-      return ZkPath.filterOutHiddenPaths(super.getChildren(path, watch));
-    }
-
-    public List<String> getChildrenNotHidden(String path, Watcher watcher) throws InterruptedException, KeeperException {
-      return ZkPath.filterOutHiddenPaths(super.getChildren(path, watcher));
-    }
+    return lvalue.intValue();
   }
+
+  public int getInt(String path) throws KeeperException, InterruptedException {
+    return Integer.parseInt(new String(getData(path, false, new Stat())));
+  }
+
+  public void setString(String path, String value) throws KeeperException, InterruptedException {
+    setData(path, value.getBytes(), -1);
+  }
+
+  public void setInt(String path, int nextVersion) throws KeeperException, InterruptedException {
+    setData(path, (Integer.toString(nextVersion)).getBytes(), -1);
+  }
+
+
 }

--- a/hank-server/src/main/java/com/liveramp/hank/test/ConfigFixtures.java
+++ b/hank-server/src/main/java/com/liveramp/hank/test/ConfigFixtures.java
@@ -1,4 +1,4 @@
-package com.liveramp.hank.fixtures;
+package com.liveramp.hank.test;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -16,31 +16,11 @@ import com.liveramp.hank.config.yaml.YamlPartitionServerConfigurator;
 import com.liveramp.hank.config.yaml.YamlRingGroupConductorConfigurator;
 import com.liveramp.hank.coordinator.Coordinator;
 import com.liveramp.hank.coordinator.PartitionServerAddress;
-import com.liveramp.hank.ring_group_conductor.RingGroupConductor;
 import com.liveramp.hank.ring_group_conductor.RingGroupConductorMode;
 
+import static com.liveramp.hank.test.CoreConfigFixtures.coordinatorConfig;
+
 public class ConfigFixtures {
-
-  public static String coordinatorConfig(int zkPort,
-                                         String domainsRoot,
-                                         String domainGroupsRoot,
-                                         String ringGroupsRoot) {
-
-    StringBuilder builder = new StringBuilder();
-
-    builder.append(
-        "coordinator:\n" +
-            "  factory: com.liveramp.hank.coordinator.zk.ZooKeeperCoordinator$Factory\n" +
-            "  options:\n" +
-            "    connect_string: localhost:").append(zkPort).append("\n")
-        .append("    session_timeout: 1000000\n");
-    builder.append("    domains_root: ").append(domainsRoot).append("\n");
-    builder.append("    domain_groups_root: ").append(domainGroupsRoot).append("\n");
-    builder.append("    ring_groups_root: ").append(ringGroupsRoot).append("\n");
-    builder.append("    max_connection_attempts: 5\n");
-
-    return builder.toString();
-  }
 
   public static String ringGroupConductorConfig(int zkPort,
                                                 String ringGroupName,
@@ -88,7 +68,7 @@ public class ConfigFixtures {
     }
     
     
-    builder.append(coordinatorConfig(zkPort, domainsRoot, domainGroupsRoot, ringGroupsRoot));
+    builder.append(coordinatorConfig(zkPort, 1000000, domainsRoot, domainGroupsRoot, ringGroupsRoot));
 
     
     
@@ -122,27 +102,9 @@ public class ConfigFixtures {
     builder.append("  " + YamlPartitionServerConfigurator.UPDATE_DAEMON_SECTION_KEY + ":\n");
     builder.append("    " + YamlPartitionServerConfigurator.NUM_CONCURRENT_UPDATES_KEY + ": 1\n");
     builder.append("    " + YamlPartitionServerConfigurator.MAX_CONCURRENT_UPDATES_PER_DATA_DIRECTORY_KEY + ": 1\n");
-    builder.append(coordinatorConfig(zkPort, domainsRoot, domainGroupsRoot, ringGroupsRoot));
+    builder.append(coordinatorConfig(zkPort, 1000000, domainsRoot, domainGroupsRoot, ringGroupsRoot));
 
     return builder.toString();
-  }
-
-  public static Coordinator createCoordinator(String tmpDir,
-                                              int zkPort,
-                                              String domainsRoot,
-                                              String domainGroupsRoot,
-                                              String ringGroupsRoot) throws IOException, InvalidConfigurationException {
-
-    String tmpFile = tmpDir + "/" + UUID.randomUUID().toString();
-
-    FileWriter fileWriter = new FileWriter(tmpFile);
-    fileWriter.append(coordinatorConfig(zkPort, domainsRoot, domainGroupsRoot, ringGroupsRoot));
-    fileWriter.close();
-
-    CoordinatorConfigurator config = new YamlClientConfigurator(tmpFile);
-
-    return config.createCoordinator();
-
   }
 
   public static RingGroupConductorConfigurator createRGCConfigurator(String tmpDir,

--- a/hank-server/src/test/java/com/liveramp/hank/IntegrationTest.java
+++ b/hank-server/src/test/java/com/liveramp/hank/IntegrationTest.java
@@ -45,11 +45,9 @@ import com.liveramp.hank.compression.cueball.GzipCueballCompressionCodec;
 import com.liveramp.hank.config.CoordinatorConfigurator;
 import com.liveramp.hank.config.InvalidConfigurationException;
 import com.liveramp.hank.config.PartitionServerConfigurator;
-import com.liveramp.hank.config.RingGroupConductorConfigurator;
 import com.liveramp.hank.config.SmartClientDaemonConfigurator;
 import com.liveramp.hank.config.yaml.YamlClientConfigurator;
 import com.liveramp.hank.config.yaml.YamlPartitionServerConfigurator;
-import com.liveramp.hank.config.yaml.YamlRingGroupConductorConfigurator;
 import com.liveramp.hank.config.yaml.YamlSmartClientDaemonConfigurator;
 import com.liveramp.hank.coordinator.Coordinator;
 import com.liveramp.hank.coordinator.Domain;
@@ -64,7 +62,7 @@ import com.liveramp.hank.coordinator.Ring;
 import com.liveramp.hank.coordinator.RingGroup;
 import com.liveramp.hank.coordinator.RingGroups;
 import com.liveramp.hank.coordinator.Rings;
-import com.liveramp.hank.fixtures.ConfigFixtures;
+import com.liveramp.hank.test.ConfigFixtures;
 import com.liveramp.hank.fixtures.PartitionServerRunnable;
 import com.liveramp.hank.fixtures.RingGroupConductorRunnable;
 import com.liveramp.hank.generated.HankBulkResponse;
@@ -74,7 +72,6 @@ import com.liveramp.hank.generated.SmartClient;
 import com.liveramp.hank.hasher.Murmur64Hasher;
 import com.liveramp.hank.partitioner.Murmur64Partitioner;
 import com.liveramp.hank.partitioner.Partitioner;
-import com.liveramp.hank.ring_group_conductor.RingGroupConductor;
 import com.liveramp.hank.ring_group_conductor.RingGroupConductorMode;
 import com.liveramp.hank.storage.LocalPartitionRemoteFileOps;
 import com.liveramp.hank.storage.StorageEngine;
@@ -86,7 +83,7 @@ import com.liveramp.hank.util.Condition;
 import com.liveramp.hank.util.WaitUntil;
 import com.liveramp.hank.zookeeper.ZkPath;
 
-import static com.liveramp.hank.fixtures.ConfigFixtures.coordinatorConfig;
+import static com.liveramp.hank.test.ConfigFixtures.coordinatorConfig;
 import static org.junit.Assert.assertEquals;
 
 public class IntegrationTest extends ZkTestCase {

--- a/hank-server/src/test/java/com/liveramp/hank/IntegrationTest.java
+++ b/hank-server/src/test/java/com/liveramp/hank/IntegrationTest.java
@@ -83,7 +83,7 @@ import com.liveramp.hank.util.Condition;
 import com.liveramp.hank.util.WaitUntil;
 import com.liveramp.hank.zookeeper.ZkPath;
 
-import static com.liveramp.hank.test.ConfigFixtures.coordinatorConfig;
+import static com.liveramp.hank.test.CoreConfigFixtures.coordinatorConfig;
 import static org.junit.Assert.assertEquals;
 
 public class IntegrationTest extends ZkTestCase {
@@ -101,7 +101,7 @@ public class IntegrationTest extends ZkTestCase {
       pw.println("  " + YamlSmartClientDaemonConfigurator.SERVICE_PORT_KEY + ": 50004");
       pw.println("  " + YamlSmartClientDaemonConfigurator.NUM_WORKER_THREADS + ": 1");
       pw.println("  " + YamlSmartClientDaemonConfigurator.RING_GROUP_NAME_KEY + ": rg1");
-      pw.println(coordinatorConfig(getZkClientPort(), domainsRoot, domainGroupsRoot, ringGroupsRoot));
+      pw.println(coordinatorConfig(getZkClientPort(), 100000, domainsRoot, domainGroupsRoot, ringGroupsRoot));
       pw.close();
       configurator = new YamlSmartClientDaemonConfigurator(configPath);
     }

--- a/hank-server/src/test/java/com/liveramp/hank/fixtures/PartitionServerRunnable.java
+++ b/hank-server/src/test/java/com/liveramp/hank/fixtures/PartitionServerRunnable.java
@@ -1,18 +1,10 @@
 package com.liveramp.hank.fixtures;
 
-import java.io.FileWriter;
-import java.io.PrintWriter;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.liveramp.hank.IntegrationTest;
 import com.liveramp.hank.config.PartitionServerConfigurator;
-import com.liveramp.hank.config.yaml.YamlPartitionServerConfigurator;
-import com.liveramp.hank.coordinator.PartitionServerAddress;
 import com.liveramp.hank.partition_server.PartitionServer;
-
-import static com.liveramp.hank.fixtures.ConfigFixtures.coordinatorConfig;
 
 public class PartitionServerRunnable implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(PartitionServerRunnable.class);

--- a/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestIntegrationAutoconfigure.java
+++ b/hank-server/src/test/java/com/liveramp/hank/ring_group_conductor/TestIntegrationAutoconfigure.java
@@ -4,16 +4,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import org.apache.log4j.Level;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Test;
@@ -21,7 +17,6 @@ import org.junit.Test;
 import com.liveramp.commons.collections.map.MapBuilder;
 import com.liveramp.hank.config.InvalidConfigurationException;
 import com.liveramp.hank.config.PartitionServerConfigurator;
-import com.liveramp.hank.config.RingGroupConductorConfigurator;
 import com.liveramp.hank.config.RingGroupConfiguredDomain;
 import com.liveramp.hank.config.yaml.YamlPartitionServerConfigurator;
 import com.liveramp.hank.coordinator.Coordinator;
@@ -34,9 +29,10 @@ import com.liveramp.hank.coordinator.HostState;
 import com.liveramp.hank.coordinator.PartitionServerAddress;
 import com.liveramp.hank.coordinator.Ring;
 import com.liveramp.hank.coordinator.RingGroup;
-import com.liveramp.hank.fixtures.ConfigFixtures;
+import com.liveramp.hank.test.ConfigFixtures;
 import com.liveramp.hank.fixtures.PartitionServerRunnable;
 import com.liveramp.hank.storage.incremental.IncrementalDomainVersionProperties;
+import com.liveramp.hank.test.CoreConfigFixtures;
 import com.liveramp.hank.test.ZkTestCase;
 import com.liveramp.hank.util.Condition;
 import com.liveramp.hank.util.WaitUntil;
@@ -64,7 +60,8 @@ public class TestIntegrationAutoconfigure extends ZkTestCase {
     create(domainGroupsRoot);
     create(ringGroupsRoot);
 
-    Coordinator coordinator = ConfigFixtures.createCoordinator(localTmpDir, getZkClientPort(),
+    Coordinator coordinator = CoreConfigFixtures.createCoordinator(localTmpDir, getZkClientPort(),
+        1000000,
         domainsRoot,
         domainGroupsRoot,
         ringGroupsRoot

--- a/hank-ui/src/main/java/com/liveramp/hank/config/MockMonitorConfigurator.java
+++ b/hank-ui/src/main/java/com/liveramp/hank/config/MockMonitorConfigurator.java
@@ -1,0 +1,20 @@
+package com.liveramp.hank.config;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import com.liveramp.hank.coordinator.RingGroup;
+import com.liveramp.hank.monitor.notifier.Notifier;
+
+public class MockMonitorConfigurator implements MonitorConfigurator{
+  @Override
+  public List<Notifier> getGlobalNotifiers() throws InvalidConfigurationException {
+    return Lists.newArrayList();
+  }
+
+  @Override
+  public List<Notifier> getRingGroupNotifiers(RingGroup ringGroup) throws InvalidConfigurationException {
+    return Lists.newArrayList();
+  }
+}

--- a/hank-ui/src/test/java/com/liveramp/hank/ui/TestWebUiServer.java
+++ b/hank-ui/src/test/java/com/liveramp/hank/ui/TestWebUiServer.java
@@ -56,9 +56,6 @@ public class TestWebUiServer extends ZkTestCase {
     ZooKeeperCoordinator zkCoord = (ZooKeeperCoordinator) coordinator;
     expireSession(zkCoord.getSessionId());
 
-    //  startup zk server
-    setupZkServer();
-
     //  verify that the ui dies because the sessions expired
     WaitUntil.orDie(() -> !hankUIRunning());
 

--- a/hank-ui/src/test/java/com/liveramp/hank/ui/TestWebUiServer.java
+++ b/hank-ui/src/test/java/com/liveramp/hank/ui/TestWebUiServer.java
@@ -1,0 +1,80 @@
+package com.liveramp.hank.ui;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Scanner;
+
+import org.junit.Test;
+
+import com.liveramp.hank.config.MockMonitorConfigurator;
+import com.liveramp.hank.coordinator.Coordinator;
+import com.liveramp.hank.coordinator.zk.ZooKeeperCoordinator;
+import com.liveramp.hank.test.CoreConfigFixtures;
+import com.liveramp.hank.test.ZkTestCase;
+import com.liveramp.hank.util.WaitUntil;
+import com.liveramp.hank.zookeeper.ZkPath;
+
+public class TestWebUiServer extends ZkTestCase {
+
+  private final String domainsRoot = ZkPath.append(getRoot(), "domains");
+  private final String domainGroupsRoot = ZkPath.append(getRoot(), "domain_groups");
+  private final String ringGroupsRoot = ZkPath.append(getRoot(), "ring_groups");
+
+  @Test
+  public void testShutdown() throws Exception {
+
+    Coordinator coordinator = CoreConfigFixtures.createCoordinator(
+        localTmpDir,
+        getZkClientPort(),
+        5000,
+        domainsRoot,
+        domainGroupsRoot,
+        ringGroupsRoot
+    );
+
+    //  start web ui
+    Thread webserverThread = new Thread(() -> {
+      try {
+        WebUiServer.start(
+            new MockMonitorConfigurator(),
+            coordinator,
+            34724
+        );
+      } catch (Exception e) {
+        System.out.println(e);
+      }
+    });
+
+    webserverThread.start();
+
+    //  verify that the ui is actually running
+    WaitUntil.orDie(() -> hankUIRunning());
+
+    //  this isn't perfect.  I'd rather kill and restart zookeeper.  the problem is that the local impl here
+    //  doesn't persist state, so the session can't reconnect after zk is restarted.  hopefully this adequately
+    //  captures the production issue of prolonged zk disconnects on restart.
+    ZooKeeperCoordinator zkCoord = (ZooKeeperCoordinator) coordinator;
+    expireSession(zkCoord.getSessionId());
+
+    //  startup zk server
+    setupZkServer();
+
+    //  verify that the ui dies because the sessions expired
+    WaitUntil.orDie(() -> !hankUIRunning());
+
+
+  }
+
+  private boolean hankUIRunning() {
+    try {
+      Scanner scanner = new Scanner(new URL("http://127.0.0.1:34724").openStream(), "UTF-8");
+      String out = scanner.useDelimiter("\\A").next();
+      scanner.close();
+      return out.contains("System Summary");
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+
+}

--- a/hank-ui/src/test/java/com/liveramp/hank/ui/WebUiServerTester.java
+++ b/hank-ui/src/test/java/com/liveramp/hank/ui/WebUiServerTester.java
@@ -100,7 +100,12 @@ public class WebUiServerTester extends ZkMockCoordinatorTestCase {
       }
     };
     WebUiServer uiServer = new WebUiServer(getWebUiMockCoordinator(), clientCache, 12345);
-    uiServer.run();
+    uiServer.run(new Runnable() {
+      @Override
+      public void run() {
+
+      }
+    });
   }
 
   private Coordinator getWebUiMockCoordinator() throws Exception {


### PR DESCRIPTION
The UI is still going stale after ZK disconnects and reconnects.  I believe it is because after a session expires and ZK reconnects, all the Watchers are lost, and WatchedMap/WatchedEnums don't update anymore, leaving the UI stale.

This adds a method addDataStateChangeListener to Coordinator, which users (in this case, the Hank UI server) can use to respond to state changes.  In this case, we want the UI to completely shut down on ZK expiry.  We already have monitoring logic to restart the UI when it is dead, so this is the most braindead way to get back into a good state.   

On a related note, all the gross overcomplicated logic in ZooKeeperPlus (which is my fault) is fairly useless, because the WatchedMaps etc still go stale, making the reconnect of limited utility.  This sweeps all that logic. 

This is hopefully adequately tested in TestWebUiServer.

To be clear -- the real fix is to rewrite all the ZkCoordinator logic using Curator instead of raw ZK watchers, and we can reconnect without worrying about losing watchers etc.  That would be a large undertaking however, and this is a much smaller change. 

@sidoh @pwestling or whoever.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/hank/335)
<!-- Reviewable:end -->
