### PR TITLE
Make zookeeper coordinator constructable directly

### DIFF
--- a/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZooKeeperCoordinator.java
+++ b/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZooKeeperCoordinator.java
@@ -164,13 +164,12 @@ public class ZooKeeperCoordinator extends ZooKeeperConnection implements Coordin
    * @throws KeeperException
    * @throws IOException
    */
-  ZooKeeperCoordinator(String zkConnectString,
-                       int sessionTimeoutMs,
-                       String domainsRoot,
-                       String domainGroupsRoot,
-                       String ringGroupsRoot,
-                       int maxConnectAttempts)
-      throws InterruptedException, KeeperException, IOException {
+  public ZooKeeperCoordinator(String zkConnectString,
+                              int sessionTimeoutMs,
+                              String domainsRoot,
+                              String domainGroupsRoot,
+                              String ringGroupsRoot,
+                              int maxConnectAttempts) throws InterruptedException, KeeperException, IOException {
     super(zkConnectString, sessionTimeoutMs, maxConnectAttempts);
     this.domainsRoot = domainsRoot;
     this.domainGroupsRoot = domainGroupsRoot;

--- a/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZooKeeperCoordinator.java
+++ b/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZooKeeperCoordinator.java
@@ -25,10 +25,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import com.google.common.collect.Lists;
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.liveramp.hank.coordinator.Coordinator;
 import com.liveramp.hank.coordinator.CoordinatorFactory;
@@ -175,9 +175,9 @@ public class ZooKeeperCoordinator extends ZooKeeperConnection implements Coordin
     this.domainGroupsRoot = domainGroupsRoot;
     this.ringGroupsRoot = ringGroupsRoot;
 
-    LOG.info("ZooKeeperCoordinator.domainsRoot: ",domainsRoot);
-    LOG.info("ZooKeeperCoordinator.domainGroupsRoot: ",domainGroupsRoot);
-    LOG.info("ZooKeeperCoordinator.ringGroupsRoot: ",ringGroupsRoot);
+    LOG.info("ZooKeeperCoordinator.domainsRoot: {}",domainsRoot);
+    LOG.info("ZooKeeperCoordinator.domainGroupsRoot: {}",domainGroupsRoot);
+    LOG.info("ZooKeeperCoordinator.ringGroupsRoot: {}",ringGroupsRoot);
 
     // Domains
     zk.ensureCreated(domainsRoot, null);


### PR DESCRIPTION
A common pattern is for these to be fixed in the client calling code. This allows constructing directly, so I can use it in object pools etc. without having nested factories for which I have to construct YAML.

Also a drive-by commit to fix the log lines in the constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/hank/339)
<!-- Reviewable:end -->
