### PR TITLE
prevent some simple invalid ring states

### DIFF
--- a/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZkRing.java
+++ b/hank-core/src/main/java/com/liveramp/hank/coordinator/zk/ZkRing.java
@@ -114,6 +114,16 @@ public class ZkRing extends AbstractRing {
   public Host addHost(PartitionServerAddress address,
                       List<String> flags) throws IOException {
     try {
+
+      //  throws an exception if we can't parse the address
+      PartitionServerAddress.parse(address.toString());
+
+      Host host = getHostByAddress(address);
+
+      if(host != null){
+        throw new IllegalArgumentException("Host "+address+" already exists in ring "+getRingNumber()+"!");
+      }
+
       return ZkHost.create(zk, coordinator, ZkPath.append(ringPath, HOSTS_PATH_SEGMENT), address, dataLocationChangeListener, flags);
     } catch (Exception e) {
       throw new IOException(e);

--- a/hank-ui/src/main/java/com/liveramp/hank/ui/controllers/RingController.java
+++ b/hank-ui/src/main/java/com/liveramp/hank/ui/controllers/RingController.java
@@ -48,7 +48,7 @@ public class RingController extends Controller {
   private void doAddHost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     String rgName = req.getParameter("rgName");
     int ringNum = Integer.parseInt(req.getParameter("ringNum"));
-    String hostname = req.getParameter("hostname");
+    String hostname = req.getParameter("hostname").trim();
     int portNum = Integer.parseInt(req.getParameter("port"));
     String flagsStr = req.getParameter("hostFlags");
     coordinator.getRingGroup(rgName).getRing(ringNum).addHost(


### PR DESCRIPTION
@davinchia this won't fix the main crashing issue we saw (still going to dig into that) but it should prevent a few of the obnoxious issues we saw yesterday during manual cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/hank/341)
<!-- Reviewable:end -->
